### PR TITLE
feat: Add multisig script generation skeleton

### DIFF
--- a/packages/common-scripts/index.d.ts
+++ b/packages/common-scripts/index.d.ts
@@ -1,5 +1,23 @@
 import { TransactionSkeleton } from "@ckb-lumos/types"
 
+export type Address = string
+export type Config = any // TODO: define this type later
+
+/**
+ * secp256k1_blake160_multisig script requires S, R, M, N and public key hashes
+ * S must be zero now
+ * and N equals to publicKeyHashes size
+ * so only need to provide R, M and public key hashes
+ */
+export interface MultisigScript {
+  /** first nth public keys must match, 1 byte */
+  R: number,
+  /** threshold, 1 byte */
+  M: number,
+  /** blake160 hashes of compressed public keys */
+  publicKeyHashes: string[],
+}
+
 // TODO: secp256k1Blake160 types
 
 export declare const secp256k1Blake160Multisig: {
@@ -15,16 +33,12 @@ export declare const secp256k1Blake160Multisig: {
    */
   transfer(
     txSkeleton: TransactionSkeleton,
-    fromAddress: string,
-    fromInfo: {
-      R: number,
-      M: number,
-      publicKeyHashes: string[],
-    },
-    toAddress: string | undefined,
-    amount: string | bigint,
+    fromAddress: Address,
+    fromInfo: MultisigScript,
+    toAddress: Address | undefined,
+    amount: bigint,
     options: {
-      config: any, // TODO: define this type later
+      config: Config,
       requiredToAddress: boolean,
     },
   ): TransactionSkeleton,
@@ -40,15 +54,11 @@ export declare const secp256k1Blake160Multisig: {
    */
   payFee(
     txSkeleton: TransactionSkeleton,
-    fromAddress: string,
-    fromInfo: {
-      R: number,
-      M: number,
-      publicKeyHashes: string[],
-    },
-    amount: string | bigint,
+    fromAddress: Address,
+    fromInfo: MultisigScript,
+    amount: bigint,
     options: {
-      config: any
+      config: Config,
     },
   ): TransactionSkeleton,
 
@@ -61,7 +71,7 @@ export declare const secp256k1Blake160Multisig: {
   prepareSigningEntries(
     txSkeleton: TransactionSkeleton,
     options: {
-      config: any,
+      config: Config,
     },
   ): TransactionSkeleton,
 
@@ -70,11 +80,7 @@ export declare const secp256k1Blake160Multisig: {
    * @param params multisig script params
    * @returns serialized multisig script
    */
-  serializeMultisigScript(params: {
-    R: number,
-    M: number,
-    publicKeyHashes: string[],
-  }): string,
+  serializeMultisigScript(params: MultisigScript): string,
 
   /**
    *

--- a/packages/common-scripts/index.d.ts
+++ b/packages/common-scripts/index.d.ts
@@ -18,6 +18,8 @@ export interface MultisigScript {
   publicKeyHashes: string[],
 }
 
+export type FromInfo = MultisigScript | Address
+
 // TODO: secp256k1Blake160 types
 
 export declare const secp256k1Blake160Multisig: {
@@ -25,16 +27,14 @@ export declare const secp256k1Blake160Multisig: {
    * transfer capacity from multisig script cells
    *
    * @param txSkeleton
-   * @param fromAddress must be multisig script address, can left empty if fromInfo exists
-   * @param fromInfo multisig parameters, required if this fromAddress is first used in this txSkeleton, can left empty if fromAddress exists
+   * @param fromInfo fromAddress or fromMultisigScript, if this address new to txSkeleton inputs, must use fromMultisigScript
    * @param toAddress can be any type of lock script and can left empty
    * @param amount transfer CKB capacity in shannon
    * @param options
    */
   transfer(
     txSkeleton: TransactionSkeleton,
-    fromAddress: Address | undefined,
-    fromInfo: MultisigScript | undefined,
+    fromInfo: FromInfo,
     toAddress: Address | undefined,
     amount: bigint,
     options: {
@@ -47,15 +47,13 @@ export declare const secp256k1Blake160Multisig: {
    * pay fee by multisig script cells
    *
    * @param txSkeleton
-   * @param fromAddress
    * @param fromInfo
    * @param amount fee in shannon
    * @param options
    */
   payFee(
     txSkeleton: TransactionSkeleton,
-    fromAddress: Address | undefined,
-    fromInfo: MultisigScript | undefined,
+    fromInfo: FromInfo,
     amount: bigint,
     options: {
       config: Config,

--- a/packages/common-scripts/index.d.ts
+++ b/packages/common-scripts/index.d.ts
@@ -1,0 +1,85 @@
+import { TransactionSkeleton } from "@ckb-lumos/types"
+
+// TODO: secp256k1Blake160 types
+
+export declare const secp256k1Blake160Multisig: {
+  /**
+   * transfer capacity from multisig script cells
+   *
+   * @param txSkeleton
+   * @param fromAddress must be multisig script address
+   * @param fromInfo multisig parameters
+   * @param toAddress can be any type of lock script and can left empty
+   * @param amount transfer CKB capacity in shannon
+   * @param options
+   */
+  transfer(
+    txSkeleton: TransactionSkeleton,
+    fromAddress: string,
+    fromInfo: {
+      R: number,
+      M: number,
+      publicKeyHashes: string[],
+    },
+    toAddress: string | undefined,
+    amount: string | bigint,
+    options: {
+      config: any, // TODO: define this type later
+      requiredToAddress: boolean,
+    },
+  ): TransactionSkeleton,
+
+  /**
+   * pay fee by multisig script cells
+   *
+   * @param txSkeleton
+   * @param fromAddress
+   * @param fromInfo
+   * @param amount fee in shannon
+   * @param options
+   */
+  payFee(
+    txSkeleton: TransactionSkeleton,
+    fromAddress: string,
+    fromInfo: {
+      R: number,
+      M: number,
+      publicKeyHashes: string[],
+    },
+    amount: string | bigint,
+    options: {
+      config: any
+    },
+  ): TransactionSkeleton,
+
+  /**
+   * prepare for txSkeleton signingEntries, will update txSkeleton.get("signingEntries")
+   *
+   * @param txSkeleton
+   * @param options
+   */
+  prepareSigningEntries(
+    txSkeleton: TransactionSkeleton,
+    options: {
+      config: any,
+    },
+  ): TransactionSkeleton,
+
+  /**
+   *
+   * @param params multisig script params
+   * @returns serialized multisig script
+   */
+  serializeMultisigScript(params: {
+    R: number,
+    M: number,
+    publicKeyHashes: string[],
+  }): string,
+
+  /**
+   *
+   * @param serializedMultisigScript
+   * @returns lock script args
+   */
+  multisigArgs(serializedMultisigScript: string): string,
+}

--- a/packages/common-scripts/index.d.ts
+++ b/packages/common-scripts/index.d.ts
@@ -25,16 +25,16 @@ export declare const secp256k1Blake160Multisig: {
    * transfer capacity from multisig script cells
    *
    * @param txSkeleton
-   * @param fromAddress must be multisig script address
-   * @param fromInfo multisig parameters
+   * @param fromAddress must be multisig script address, can left empty if fromInfo exists
+   * @param fromInfo multisig parameters, required if this fromAddress is first used in this txSkeleton, can left empty if fromAddress exists
    * @param toAddress can be any type of lock script and can left empty
    * @param amount transfer CKB capacity in shannon
    * @param options
    */
   transfer(
     txSkeleton: TransactionSkeleton,
-    fromAddress: Address,
-    fromInfo: MultisigScript,
+    fromAddress: Address | undefined,
+    fromInfo: MultisigScript | undefined,
     toAddress: Address | undefined,
     amount: bigint,
     options: {
@@ -54,8 +54,8 @@ export declare const secp256k1Blake160Multisig: {
    */
   payFee(
     txSkeleton: TransactionSkeleton,
-    fromAddress: Address,
-    fromInfo: MultisigScript,
+    fromAddress: Address | undefined,
+    fromInfo: MultisigScript | undefined,
     amount: bigint,
     options: {
       config: Config,

--- a/packages/common-scripts/lib/index.js
+++ b/packages/common-scripts/lib/index.js
@@ -1,3 +1,4 @@
 module.exports = {
   secp256k1Blake160: require("./secp256k1_blake160"),
+  secp256k1Blake160Multisig: require("./secp256k1_blake160_multisig"),
 };

--- a/packages/common-scripts/lib/secp256k1_blake160.js
+++ b/packages/common-scripts/lib/secp256k1_blake160.js
@@ -195,7 +195,7 @@ async function transfer(
     }
     let witness = txSkeleton.get("witnesses").get(firstIndex);
     const newWitnessArgs = {
-      /* 65 bytes zeros in hex */
+      /* 65-byte zeros in hex */
       lock: SIGNATURE_PLACEHOLDER,
     };
     if (witness !== "0x") {

--- a/packages/common-scripts/lib/secp256k1_blake160_multisig.js
+++ b/packages/common-scripts/lib/secp256k1_blake160_multisig.js
@@ -27,17 +27,6 @@ function ensureSecp256k1Blake160Multisig(script, config) {
   }
 }
 
-/**
- * secp256k1_blake160_multisig requires S, R, M, N and public key hashes
- * S must be zero now
- * and N equals publicKeyHashes.length
- * so only need to provide R, M and public key hashes
- *
- * @param {number} R first nth public keys must match
- * @param {number} M threshold
- * @param {string[]} publicKeyHashes blake160 hash of public keys
- * @returns {string} multisig script
- */
 function serializeMultisigScript({ R, M, publicKeyHashes }) {
   if (R < 0 || R > 255) {
     throw new Error("`R` should be less than 256!");
@@ -55,11 +44,6 @@ function serializeMultisigScript({ R, M, publicKeyHashes }) {
   );
 }
 
-/**
- *
- * @param {string} serializedMultisigScript
- * @returns {string} lock script args
- */
 function multisigArgs(serializedMultisigScript) {
   return new CKBHasher()
     .update(serializedMultisigScript)

--- a/packages/common-scripts/lib/secp256k1_blake160_multisig.js
+++ b/packages/common-scripts/lib/secp256k1_blake160_multisig.js
@@ -11,54 +11,110 @@ const { ScriptValue } = values;
 const { normalizers, Reader } = require("ckb-js-toolkit");
 const { Set } = require("immutable");
 
+// 65 bytes zeros
 const SIGNATURE_PLACEHOLDER =
   "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
 
-function ensureSecp256k1Script(script, config) {
-  const template = config.SCRIPTS.SECP256K1_BLAKE160.SCRIPT;
+function ensureSecp256k1Blake160Multisig(script, config) {
+  const template = config.SCRIPTS.SECP256K1_BLAKE160_MULTISIG.SCRIPT;
   if (
     template.code_hash !== script.code_hash ||
     template.hash_type !== script.hash_type
   ) {
-    throw new Error("Provided script is not SECP256K1_BLAKE160 script!");
+    throw new Error(
+      "Provided script is not SECP256K1_BLAKE160_MULTISIG script!"
+    );
   }
+}
+
+/**
+ * secp256k1_blake160_multisig requires S, R, M, N and public key hashes
+ * S must be zero now
+ * and N equals publicKeyHashes.length
+ * so only need to provide R, M and public key hashes
+ *
+ * @param {number} R first nth public keys must match
+ * @param {number} M threshold
+ * @param {string[]} publicKeyHashes blake160 hash of public keys
+ * @returns {string} multisig script
+ */
+function serializeMultisigScript({ R, M, publicKeyHashes }) {
+  if (R < 0 || R > 255) {
+    throw new Error("`R` should be less than 256!");
+  }
+  if (M < 0 || M > 255) {
+    throw new Error("`M` should be less than 256!");
+  }
+  // TODO: validate publicKeyHashes
+  return (
+    "0x00" +
+    ("00" + R.toString(16)).slice(-2) +
+    ("00" + M.toString(16)).slice(-2) +
+    ("00" + publicKeyHashes.length.toString(16)).slice(-2) +
+    publicKeyHashes.map((h) => h.slice(2)).join("")
+  );
+}
+
+/**
+ *
+ * @param {string} serializedMultisigScript
+ * @returns {string} lock script args
+ */
+function multisigArgs(serializedMultisigScript) {
+  return new CKBHasher()
+    .update(serializedMultisigScript)
+    .digestHex()
+    .slice(0, 42);
 }
 
 async function transfer(
   txSkeleton,
   fromAddress,
+  { R, M, publicKeyHashes },
   toAddress,
   amount,
-  { config = LINA, requireToAddress = true } = {}
+  { config = LINA, requireToAddress = true }
 ) {
-  if (!config.SCRIPTS.SECP256K1_BLAKE160) {
+  if (!config.SCRIPTS.SECP256K1_BLAKE160_MULTISIG) {
     throw new Error(
-      "Provided config does not have SECP256K1_BLAKE160 script setup!"
+      "Provided config does not have SECP256K1_BLAKE16_MULTISIG script setup!"
     );
   }
 
   const cellDep = txSkeleton.get("cellDeps").find((cellDep) => {
     return (
-      cellDep.dep_type === config.SCRIPTS.SECP256K1_BLAKE160.DEP_TYPE &&
+      cellDep.dep_type ===
+        config.SCRIPTS.SECP256K1_BLAKE160_MULTISIG.DEP_TYPE &&
       new values.OutPointValue(cellDep.out_point, { validate: false }).equals(
-        new values.OutPointValue(config.SCRIPTS.SECP256K1_BLAKE160.OUT_POINT, {
-          validate: false,
-        })
+        new values.OutPointValue(
+          config.SCRIPTS.SECP256K1_BLAKE160_MULTISIG.OUT_POINT,
+          {
+            validate: false,
+          }
+        )
       )
     );
   });
+
   if (!cellDep) {
     txSkeleton = txSkeleton.update("cellDeps", (cellDeps) => {
       return cellDeps.push({
-        out_point: config.SCRIPTS.SECP256K1_BLAKE160.OUT_POINT,
-        dep_type: config.SCRIPTS.SECP256K1_BLAKE160.DEP_TYPE,
+        out_point: config.SCRIPTS.SECP256K1_BLAKE160_MULTISIG.OUT_POINT,
+        dep_type: config.SCRIPTS.SECP256K1_BLAKE160_MULTISIG.DEP_TYPE,
       });
     });
   }
 
   amount = BigInt(amount);
   const fromScript = parseAddress(fromAddress, { config });
-  ensureSecp256k1Script(fromScript, config);
+  ensureSecp256k1Blake160Multisig(fromScript, config);
+
+  // validate args
+  const multisigScript = serializeMultisigScript({ R, M, publicKeyHashes });
+  const fromScriptArgs = multisigArgs(multisigScript);
+  if (fromScript.args !== fromScriptArgs) {
+    throw new Error("R M and publicKeyHashes infos not match to fromAddress!");
+  }
 
   if (requireToAddress && !toAddress) {
     throw new Error("You must provide a to address!");
@@ -80,20 +136,12 @@ async function transfer(
     });
   }
 
-  /*
-   * First, check if there is any output cells that contains enough capacity
-   * for us to tinker with.
-   *
-   * TODO: the solution right now won't cover all cases, some outputs before the
-   * last output might still be tinkerable, right now we are working on the
-   * simple solution, later we can change this for more optimizations.
-   */
   const lastFreezedOutput = txSkeleton
     .get("fixedEntries")
     .filter(({ field }) => field === "outputs")
     .maxBy(({ index }) => index);
   let i = lastFreezedOutput ? lastFreezedOutput.index + 1 : 0;
-  for (; i < txSkeleton.get("outputs").size && amount > 0; i++) {
+  for (; i < txSkeleton.get("outputs").size && amount > 0; ++i) {
     const output = txSkeleton.get("outputs").get(i);
     if (
       new ScriptValue(output.cell_output.lock, { validate: false }).equals(
@@ -115,7 +163,7 @@ async function transfer(
         "0x" + (cellCapacity - deductCapacity).toString(16);
     }
   }
-  // Remove all output cells with capacity equal to 0
+  // remove all output cells with capacity equal to 0
   txSkeleton = txSkeleton.update("outputs", (outputs) => {
     return outputs.filter(
       (output) => BigInt(output.cell_output.capacity) !== BigInt(0)
@@ -127,8 +175,9 @@ async function transfer(
   if (amount > 0) {
     const cellProvider = txSkeleton.get("cellProvider");
     if (!cellProvider) {
-      throw new Error("Cell provider is missing!");
+      throw new Error("cell provider is missing!");
     }
+    // TODO: ignore locktime now.
     const cellCollector = cellProvider.collector({
       lock: fromScript,
     });
@@ -175,11 +224,7 @@ async function transfer(
   if (amount > 0) {
     throw new Error("Not enough capacity in from address!");
   }
-  /*
-   * Modify the skeleton, so the first witness of the fromAddress script group
-   * has a WitnessArgs construct with 65-byte zero filled values. While this
-   * is not required, it helps in transaction fee estimation.
-   */
+
   const firstIndex = txSkeleton
     .get("inputs")
     .findIndex((input) =>
@@ -195,8 +240,10 @@ async function transfer(
     }
     let witness = txSkeleton.get("witnesses").get(firstIndex);
     const newWitnessArgs = {
-      /* 65 bytes zeros in hex */
-      lock: SIGNATURE_PLACEHOLDER,
+      lock:
+        "0x" +
+        multisigScript.slice(2) +
+        SIGNATURE_PLACEHOLDER.slice(2).repeat(M),
     };
     if (witness !== "0x") {
       const witnessArgs = new core.WitnessArgs(new Reader(witness));
@@ -212,7 +259,7 @@ async function transfer(
       const inputType = witnessArgs.getInputType();
       if (inputType.hasValue()) {
         newWitnessArgs.input_type = new Reader(
-          inputType.value().raw()
+          inputType.values().raw()
         ).serializeJson();
       }
       const outputType = witnessArgs.getOutputType();
@@ -234,8 +281,14 @@ async function transfer(
   return txSkeleton;
 }
 
-async function payFee(txSkeleton, fromAddress, amount, { config = LINA } = {}) {
-  return await transfer(txSkeleton, fromAddress, null, amount, {
+async function payFee(
+  txSkeleton,
+  fromAddress,
+  fromInfo,
+  amount,
+  { config = LINA } = {}
+) {
+  return transfer(txSkeleton, fromAddress, fromInfo, null, amount, {
     config,
     requireToAddress: false,
   });
@@ -250,12 +303,12 @@ function hashWitness(hasher, witness) {
 }
 
 function prepareSigningEntries(txSkeleton, { config = LINA } = {}) {
-  if (!config.SCRIPTS.SECP256K1_BLAKE160) {
+  if (!config.SCRIPTS.SECP256K1_BLAKE160_MULTISIG) {
     throw new Error(
-      "Provided config does not have SECP256K1_BLAKE160 script setup!"
+      "Provided config does not have SECP256K1_BLAKE160_MULTISIG script setup!"
     );
   }
-  const template = config.SCRIPTS.SECP256K1_BLAKE160.SCRIPT;
+  const template = config.SCRIPTS.SECP256K1_BLAKE160_MULTISIG.SCRIPT;
   let processedArgs = Set();
   const tx = createTransactionFromSkeleton(txSkeleton);
   const txHash = ckbHash(
@@ -314,4 +367,6 @@ module.exports = {
   transfer,
   payFee,
   prepareSigningEntries,
+  serializeMultisigScript,
+  multisigArgs,
 };

--- a/packages/helpers/lib/configs.js
+++ b/packages/helpers/lib/configs.js
@@ -18,6 +18,20 @@ const LINA = {
       DEP_TYPE: "dep_group",
       SHORT_ID: 0,
     },
+    SECP256K1_BLAKE160_MULTISIG: {
+      SCRIPT: {
+        code_hash:
+          "0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8",
+        hash_type: "type",
+      },
+      OUT_POINT: {
+        tx_hash:
+          "0x71a7ba8fc96349fea0ed3a5c47992e3b4084b031a42264a018e0072e8172e46c",
+        index: "0x1",
+      },
+      DEP_TYPE: "dep_group",
+      SHORT_ID: 1,
+    },
   },
 };
 
@@ -37,6 +51,20 @@ const AGGRON4 = {
       },
       DEP_TYPE: "dep_group",
       SHORT_ID: 0,
+    },
+    SECP256K1_BLAKE160_MULTISIG: {
+      SCRIPT: {
+        code_hash:
+          "0x5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8",
+        hash_type: "type",
+      },
+      OUT_POINT: {
+        tx_hash:
+          "0x6495cede8d500e4309218ae50bbcadb8f722f24cc7572dd2274f5876cb603e4e",
+        index: "0x1",
+      },
+      DEP_TYPE: "dep_group",
+      SHORT_ID: 1,
     },
   },
 };

--- a/packages/helpers/lib/index.js
+++ b/packages/helpers/lib/index.js
@@ -32,6 +32,7 @@ function minimalCellCapacity(fullCell, { validate = true } = {}) {
   let bytes = 8;
   bytes += new Reader(fullCell.cell_output.lock.code_hash).length();
   bytes += new Reader(fullCell.cell_output.lock.args).length();
+  // hash_type field
   bytes += 1;
   if (fullCell.cell_output.type) {
     bytes += new Reader(fullCell.cell_output.type.code_hash).length();
@@ -66,7 +67,7 @@ function generateAddress(script, { config = LINA } = {}) {
       s.SCRIPT.hash_type === script.hash_type
   );
   const data = [];
-  if (scriptTemplate) {
+  if (scriptTemplate && scriptTemplate.SHORT_ID !== undefined) {
     data.push(1, scriptTemplate.SHORT_ID);
     data.push(...hexToByteArray(script.args));
   } else {

--- a/packages/helpers/lib/index.js
+++ b/packages/helpers/lib/index.js
@@ -35,7 +35,6 @@ function minimalCellCapacity(fullCell, { validate = true } = {}) {
   bytes += new Reader(fullCell.cell_output.lock.code_hash).length();
   bytes += new Reader(fullCell.cell_output.lock.args).length();
   // hash_type field
-  // hash_type field
   bytes += 1;
   if (fullCell.cell_output.type) {
     bytes += new Reader(fullCell.cell_output.type.code_hash).length();


### PR DESCRIPTION
* I'm not sure should we use `R` and `M` or more readable `require_n` and `threshold`, former one is more friendly to who's familiar with `secp256k1_blake160_multisig`.
* Should we retain `fromAddress`, or we can delete this parameter and generate `fromScript` from `fromInfo(R, M, publicKeyHashes and so on...)` ?
* Should we expose `serializeMultisigScript` and `multisigArgs`, these will help to generate multisig address, or we can move to somewhere like `utils` ?