### PR TITLE
fix: AND semantic should be used when lock and type are both used.

### DIFF
--- a/packages/indexer/lib/index.js
+++ b/packages/indexer/lib/index.js
@@ -39,30 +39,6 @@ class Indexer {
     return this.nativeIndexer.tip();
   }
 
-  getLiveCellsByLockScript(
-    script,
-    { validateFirst = true, returnRawBuffer = false } = {}
-  ) {
-    return this._getLiveCellsByScript(
-      script,
-      0,
-      validateFirst,
-      returnRawBuffer
-    );
-  }
-
-  getLiveCellsByTypeScript(
-    script,
-    { validateFirst = true, returnRawBuffer = false } = {}
-  ) {
-    return this._getLiveCellsByScript(
-      script,
-      1,
-      validateFirst,
-      returnRawBuffer
-    );
-  }
-
   _getLiveCellsByScript(script, scriptType, validateFirst, returnRawBuffer) {
     if (validateFirst) {
       validators.ValidateScript(script);
@@ -72,14 +48,6 @@ class Indexer {
       scriptType,
       returnRawBuffer
     );
-  }
-
-  getTransactionsByLockScriptIterator(script, { validateFirst = true } = {}) {
-    return this._getTransactionsByScriptIterator(script, 0, validateFirst);
-  }
-
-  getTransactionsByTypeScriptIterator(script, { validateFirst = true } = {}) {
-    return this._getTransactionsByScriptIterator(script, 1, validateFirst);
   }
 
   _getTransactionsByScriptIterator(script, scriptType, validateFirst) {
@@ -148,30 +116,63 @@ class CellCollector {
     this.skipNotLive = skipNotLive;
   }
 
+  // TODO: optimize this
+  async count() {
+    let result = 0;
+    const c = this.collect();
+    while (true) {
+      const item = await c.next();
+      if (item.done) {
+        break;
+      }
+      result += 1;
+    }
+    return result;
+  }
+
   async *collect() {
-    let outPoints = new Set();
-    if (this.lock) {
-      for (const o of this.indexer.getLiveCellsByLockScript(this.lock, {
-        validateFirst: false,
-        returnRawBuffer: true,
-      })) {
-        outPoints = outPoints.add(new BufferValue(o));
+    if (this.lock && this.type) {
+      let lockOutPoints = new Set();
+      for (const o of this.indexer._getLiveCellsByScript(
+        this.lock,
+        0,
+        false,
+        true
+      )) {
+        lockOutPoints = lockOutPoints.add(new BufferValue(o));
       }
-    }
-    if (this.type) {
-      for (const o of this.indexer.getLiveCellsByTypeScript(this.type, {
-        validateFirst: false,
-        returnRawBuffer: true,
-      })) {
-        outPoints = outPoints.add(new BufferValue(o));
+      let typeOutPoints = new Set();
+      for (const o of this.indexer._getLiveCellsByScript(
+        this.type,
+        1,
+        false,
+        true
+      )) {
+        typeOutPoints = typeOutPoints.add(new BufferValue(o));
       }
-    }
-    for (const o of outPoints) {
-      const cell = this.indexer.nativeIndexer.getDetailedLiveCell(o.buffer);
-      if (!this.skipNotLive && !cell) {
-        throw new Error(`Cell ${o.tx_hash} @ ${o.index} is not live!`);
+      const outPoints = lockOutPoints.intersect(typeOutPoints);
+      for (const o of outPoints) {
+        const cell = this.indexer.nativeIndexer.getDetailedLiveCell(o.buffer);
+        if (!this.skipNotLive && !cell) {
+          throw new Error(`Cell ${o.tx_hash} @ ${o.index} is not live!`);
+        }
+        yield cell;
       }
-      yield cell;
+    } else {
+      const script = this.lock || this.type;
+      const scriptType = !!this.lock ? 0 : 1;
+      for (const o of this.indexer._getLiveCellsByScript(
+        script,
+        scriptType,
+        false,
+        true
+      )) {
+        const cell = this.indexer.nativeIndexer.getDetailedLiveCell(o);
+        if (!this.skipNotLive && !cell) {
+          throw new Error(`Cell ${o.tx_hash} @ ${o.index} is not live!`);
+        }
+        yield cell;
+      }
     }
   }
 }
@@ -204,18 +205,46 @@ class TransactionCollector {
     this.rpc = new RPC(indexer.uri);
   }
 
+  async count() {
+    if (this.lock && this.type) {
+      const lockHashes = new Set(
+        this.indexer
+          ._getTransactionsByScriptIterator(this.lock, 0, false)
+          .collect()
+      );
+      const typeHashes = new Set(
+        this.indexer
+          ._getTransactionsByScriptIterator(this.type, 1, false)
+          .collect()
+      );
+      const hashes = lockHashes.intersect(typeHashes);
+      return hashes.size;
+    } else {
+      const script = this.lock || this.type;
+      const scriptType = !!this.lock ? 0 : 1;
+      const iter = this.indexer._getTransactionsByScriptIterator(
+        script,
+        scriptType,
+        false
+      );
+      return iter.count();
+    }
+  }
+
   async *collect() {
-    let hashes = new Set();
-    if (this.lock) {
-      const iter = this.indexer.getTransactionsByLockScriptIterator(this.lock, {
-        validateFirst: false,
-      });
-      while (true) {
-        const hash = iter.next();
-        if (!hash) {
-          break;
-        }
-        hashes = hashes.add(hash);
+    if (this.lock && this.type) {
+      const lockHashes = new Set(
+        this.indexer
+          ._getTransactionsByScriptIterator(this.lock, 0, false)
+          .collect()
+      );
+      const typeHashes = new Set(
+        this.indexer
+          ._getTransactionsByScriptIterator(this.type, 1, false)
+          .collect()
+      );
+      const hashes = lockHashes.intersect(typeHashes);
+      for (const h of hashes) {
         const tx = await this.rpc.get_transaction(hash);
         if (!this.skipMissing && !tx) {
           throw new Error(`Transaction ${h} is missing!`);
@@ -226,18 +255,18 @@ class TransactionCollector {
           yield tx.transaction;
         }
       }
-    }
-    if (this.type) {
-      const iter = this.indexer.getTransactionsByTypeScriptIterator(this.type, {
-        validateFirst: false,
-      });
+    } else {
+      const script = this.lock || this.type;
+      const scriptType = !!this.lock ? 0 : 1;
+      const iter = this.indexer._getTransactionsByScriptIterator(
+        script,
+        scriptType,
+        false
+      );
       while (true) {
         const hash = iter.next();
         if (!hash) {
           break;
-        }
-        if (hashes.has(hash)) {
-          continue;
         }
         const tx = await this.rpc.get_transaction(hash);
         if (!this.skipMissing && !tx) {


### PR DESCRIPTION
Previously we were doing an OR operation when lock and type are both
used in query. Upon further thinking, it's better if we can instead
implement AND logic here. OR logic can easily be achieved via multiple collector.