### PR TITLE
fix: Fix typo and object outpoints intersection error

### DIFF
--- a/packages/indexer/README.md
+++ b/packages/indexer/README.md
@@ -44,6 +44,27 @@ for await (const cell of collector.collect()) {
 }
 ```
 
+You can also specify both `lock` and `type` script: 
+```javascript
+collector = new CellCollector(indexer, {
+    lock: {
+        args: "0x92aad3bbab20f225cff28ec1d856c6ab63284c7a",
+        code_hash: "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+        hash_type: "type"
+    },
+    type: {
+        args: "0x",
+        code_hash: "0x82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e",
+        hash_type: "type"
+    }
+})
+
+for await (const cell of collector.collect()) {
+  console.log(cell);
+}
+```
+
+
 Prefix search is supported on `args`.
 
 Range query for cells between given block_numbers is supported:

--- a/packages/indexer/lib/index.js
+++ b/packages/indexer/lib/index.js
@@ -204,7 +204,7 @@ class CellCollector {
     );
   }
   isOutPointEqual(a, b) {
-    return a.tx_hash == b.tx_hash && a.index == b.index;
+    return a.tx_hash === b.tx_hash && a.index === b.index;
   }
 
   async count() {

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -38,7 +38,6 @@
     "@ckb-lumos/base": "^0.6.0",
     "ckb-js-toolkit": "^0.9.1",
     "immutable": "^4.0.0-rc.12",
-    "lodash": "^4.17.19",
     "neon-cli": "^0.4.0",
     "node-pre-gyp": "^0.14.0",
     "request": "^2.88.2",

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -10,8 +10,14 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "cpu": ["x64"],
-  "os": ["win32", "darwin", "linux"],
+  "cpu": [
+    "x64"
+  ],
+  "os": [
+    "win32",
+    "darwin",
+    "linux"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nervosnetwork/lumos.git"
@@ -32,6 +38,7 @@
     "@ckb-lumos/base": "^0.6.0",
     "ckb-js-toolkit": "^0.9.1",
     "immutable": "^4.0.0-rc.12",
+    "lodash": "^4.17.19",
     "neon-cli": "^0.4.0",
     "node-pre-gyp": "^0.14.0",
     "request": "^2.88.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2561,7 +2561,7 @@ lodash.padend@^4.6.1:
   resolved "https://registry.yarnpkg.com/lodash.padend/-/lodash.padend-4.6.1.tgz#53ccba047d06e158d311f45da625f4e49e6f166e"
   integrity sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.3.0:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.3.0:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2561,7 +2561,7 @@ lodash.padend@^4.6.1:
   resolved "https://registry.yarnpkg.com/lodash.padend/-/lodash.padend-4.6.1.tgz#53ccba047d06e158d311f45da625f4e49e6f166e"
   integrity sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=
 
-lodash@^4.17.14, lodash@^4.17.15, lodash@^4.3.0:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.3.0:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==


### PR DESCRIPTION
Fix #75, the OrderedSet's intersect function can't perform object level comparison, so it will always return a empty result.