### PR TITLE
Add default options of Transaction Manager

### DIFF
--- a/packages/transaction-manager/lib/index.js
+++ b/packages/transaction-manager/lib/index.js
@@ -10,7 +10,7 @@ function defaultLogger(level, message) {
 class TransactionManager {
   constructor(
     indexer,
-    { logger = defaultLogger, pollIntervalSeconds = 30 } = {}
+    { logger = defaultLogger, pollIntervalSeconds = 30 } = { logger: defaultLogger, pollIntervalSeconds: 30 }
   ) {
     this.indexer = indexer;
     this.rpc = new RPC(indexer.uri);


### PR DESCRIPTION
Fix the error from undefined `logger` and `pollIntervalSeconds` due to the default `{}` of the second parameter.