### PR TITLE
fix: Update `defaultWitness` to undefined in `common#setupInputCell`

### DIFF
--- a/packages/common-scripts/src/common.ts
+++ b/packages/common-scripts/src/common.ts
@@ -593,7 +593,7 @@ export async function setupInputCell(
     config = undefined,
     needCapacity = undefined,
     since = undefined,
-    defaultWitness = "0x",
+    defaultWitness = undefined,
   }: Options & {
     needCapacity?: HexString;
     since?: PackedSince;


### PR DESCRIPTION
For every lock script can use it's own `defaultWitness`