### PR TITLE
Easy generate address

### DIFF
--- a/packages/hd/src/key.ts
+++ b/packages/hd/src/key.ts
@@ -78,9 +78,15 @@ export function publicKeyToBlake160(publicKey: HexString): HexString {
   return blake160;
 }
 
+export function privateKeyToBlake160(privateKey: HexString): HexString {
+  const publicKey: HexString = privateToPublic(privateKey);
+  return publicKeyToBlake160(publicKey);
+}
+
 export default {
   signRecoverable,
   recoverFromSignature,
   privateToPublic,
   publicKeyToBlake160,
+  privateKeyToBlake160,
 };

--- a/packages/hd/tests/key.test.ts
+++ b/packages/hd/tests/key.test.ts
@@ -5,6 +5,7 @@ const {
   recoverFromSignature,
   privateToPublic,
   publicKeyToBlake160,
+  privateKeyToBlake160,
 } = key;
 
 const signInfo = {
@@ -72,5 +73,10 @@ test("privateToPublic, derive public key from private key wrong length", (t) => 
 
 test("publicKeyToBlake160", (t) => {
   const blake160 = publicKeyToBlake160(signInfo.publicKey);
+  t.is(blake160, signInfo.blake160);
+});
+
+test("privateKeyToBlake160", (t) => {
+  const blake160 = privateKeyToBlake160(signInfo.privateKey);
   t.is(blake160, signInfo.blake160);
 });

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -110,6 +110,38 @@ export function generateAddress(
 
 export const scriptToAddress = generateAddress;
 
+function generatePredefinedAddress(
+  args: HexString,
+  scriptType: string,
+  { config = undefined }: Options = {}
+): Address {
+  config = config || getConfig();
+  const template = config.SCRIPTS[scriptType]!;
+  const script: Script = {
+    code_hash: template.CODE_HASH,
+    hash_type: template.HASH_TYPE,
+    args,
+  };
+
+  return generateAddress(script, { config });
+}
+
+export function generateSecp256k1Blake160Address(
+  args: HexString,
+  { config = undefined }: Options = {}
+): Address {
+  return generatePredefinedAddress(args, "SECP256K1_BLAKE160", { config });
+}
+
+export function generateSecp256k1Blake160MultisigAddress(
+  args: HexString,
+  { config = undefined }: Options = {}
+): Address {
+  return generatePredefinedAddress(args, "SECP256K1_BLAKE160_MULTISIG", {
+    config,
+  });
+}
+
 export function parseAddress(
   address: Address,
   { config = undefined }: Options = {}

--- a/packages/helpers/tests/generate_address.test.ts
+++ b/packages/helpers/tests/generate_address.test.ts
@@ -1,5 +1,10 @@
 import test from "ava";
-import { generateAddress, scriptToAddress } from "../src";
+import {
+  generateAddress,
+  generateSecp256k1Blake160Address,
+  generateSecp256k1Blake160MultisigAddress,
+  scriptToAddress,
+} from "../src";
 import { predefined } from "@ckb-lumos/config-manager";
 const { LINA, AGGRON4 } = predefined;
 import {
@@ -56,4 +61,40 @@ test("short address, mainnet, scriptToAddress", (t) => {
   const address = scriptToAddress(shortAddressInfo.script, { config: LINA });
 
   t.is(address, shortAddressInfo.mainnetAddress);
+});
+
+test("generateSecp256k1Blake160Address, testnet", (t) => {
+  const address = generateSecp256k1Blake160Address(
+    shortAddressInfo.script.args,
+    { config: AGGRON4 }
+  );
+
+  t.is(address, shortAddressInfo.testnetAddress);
+});
+
+test("generateSecp256k1Blake160Address, mainnet", (t) => {
+  const address = generateSecp256k1Blake160Address(
+    shortAddressInfo.script.args,
+    { config: LINA }
+  );
+
+  t.is(address, shortAddressInfo.mainnetAddress);
+});
+
+test("generateSecp256k1Blake160MultisigAddress, testnet", (t) => {
+  const address = generateSecp256k1Blake160MultisigAddress(
+    multisigAddressInfo.script.args,
+    { config: AGGRON4 }
+  );
+
+  t.is(address, multisigAddressInfo.testnetAddress);
+});
+
+test("generateSecp256k1Blake160MultisigAddress, mainnet", (t) => {
+  const address = generateSecp256k1Blake160MultisigAddress(
+    multisigAddressInfo.script.args,
+    { config: LINA }
+  );
+
+  t.is(address, multisigAddressInfo.mainnetAddress);
 });


### PR DESCRIPTION
Make generate `secp256k1_blake160` address from private key easily.

before
```javascript
const publicKey = key.privateToPublic(privateKey);
const blake160 = key.publicKeyToBlake160(publicKey);
const script = {
    code_hash: config.SCRIPTS.SECP256K1_BLAKE160.CODE_HASH,
    hash_type: config.SCRIPTS.SECP256K1_BLAKE160.HASH_TYPE,
    args: blake160,
}
const address = generateAddress(script, { config })
```

after
```javascript
const address = generateSecp256k1Blake160Address(
    key.privateKeyToBlake160(privateKey),
    { config }
)
```
