### PR TITLE
Fix validate since

### DIFF
--- a/packages/base/index.d.ts
+++ b/packages/base/index.d.ts
@@ -289,7 +289,9 @@ export declare const since: {
   validateSince(
     since: PackedSince,
     tipHeader: Header,
-    sinceHeader?: Header
+    sinceHeader?: Header,
+    tipMedianTimestamp?: HexNumber,
+    cellMedianTimestamp?: HexNumber
   ): boolean;
 
   /**

--- a/packages/base/index.d.ts
+++ b/packages/base/index.d.ts
@@ -220,6 +220,12 @@ export interface EpochSinceValue {
 
 export type SinceType = "epochNumber" | "blockNumber" | "blockTimestamp";
 
+export interface SinceValidationInfo {
+  block_number: HexNumber;
+  epoch: HexNumber;
+  median_timestamp: HexNumber;
+}
+
 export declare const since: {
   /**
    * Parse since and get relative or not, type, and value of since
@@ -288,10 +294,8 @@ export declare const since: {
    */
   validateSince(
     since: PackedSince,
-    tipHeader: Header,
-    sinceHeader?: Header,
-    tipMedianTimestamp?: HexNumber,
-    cellMedianTimestamp?: HexNumber
+    tipSinceValidationInfo: SinceValidationInfo,
+    cellSinceValidationInfo?: SinceValidationInfo
   ): boolean;
 
   /**

--- a/packages/base/lib/since.js
+++ b/packages/base/lib/since.js
@@ -115,7 +115,13 @@ function validateAbsoluteEpochSince(since, tipHeaderEpoch) {
   );
 }
 
-function validateSince(since, tipHeader, sinceHeader) {
+function validateSince(
+  since,
+  tipHeader,
+  sinceHeader,
+  tipMedianTimestamp,
+  cellMedianTimestamp
+) {
   const { relative, type, value } = parseSince(since);
   if (!relative) {
     if (type === "epochNumber") {
@@ -125,7 +131,11 @@ function validateSince(since, tipHeader, sinceHeader) {
       return value <= BigInt(tipHeader.number);
     }
     if (type === "blockTimestamp") {
-      return value * 1000n <= BigInt(tipHeader.timestamp);
+      if (!tipMedianTimestamp) {
+        throw new Error(`Must provide tipMedianTimestamp!`);
+      }
+
+      return value * 1000n <= BigInt(tipMedianTimestamp);
     }
   } else {
     if (type === "epochNumber") {
@@ -161,9 +171,15 @@ function validateSince(since, tipHeader, sinceHeader) {
       return value + BigInt(sinceHeader.number) <= BigInt(tipHeader.number);
     }
     if (type === "blockTimestamp") {
+      if (!tipMedianTimestamp || !cellMedianTimestamp) {
+        throw new Error(
+          `Must provide tipMediamTimestamp and cellMedianTimestamp!`
+        );
+      }
+
       return (
-        value * 1000n + BigInt(sinceHeader.timestamp) <=
-        BigInt(tipHeader.timestamp)
+        value * 1000n + BigInt(cellMedianTimestamp) <=
+        BigInt(tipMedianTimestamp)
       );
     }
   }

--- a/packages/base/lib/since.js
+++ b/packages/base/lib/since.js
@@ -115,32 +115,28 @@ function validateAbsoluteEpochSince(since, tipHeaderEpoch) {
   );
 }
 
-function validateSince(
-  since,
-  tipHeader,
-  sinceHeader,
-  tipMedianTimestamp,
-  cellMedianTimestamp
-) {
+function validateSince(since, tipSinceValidationInfo, cellSinceValidationInfo) {
   const { relative, type, value } = parseSince(since);
   if (!relative) {
     if (type === "epochNumber") {
-      return validateAbsoluteEpochSince(since, tipHeader.epoch);
+      return validateAbsoluteEpochSince(since, tipSinceValidationInfo.epoch);
     }
     if (type === "blockNumber") {
-      return value <= BigInt(tipHeader.number);
+      return value <= BigInt(tipSinceValidationInfo.block_number);
     }
     if (type === "blockTimestamp") {
-      if (!tipMedianTimestamp) {
-        throw new Error(`Must provide tipMedianTimestamp!`);
+      if (!tipSinceValidationInfo.median_timestamp) {
+        throw new Error(`Must provide tip median_timestamp!`);
       }
 
-      return value * 1000n <= BigInt(tipMedianTimestamp);
+      return value * 1000n <= BigInt(tipSinceValidationInfo.median_timestamp);
     }
   } else {
     if (type === "epochNumber") {
-      const tipHeaderEpoch = parseEpoch(BigInt(tipHeader.epoch));
-      const sinceHeaderEpoch = parseEpoch(BigInt(sinceHeader.epoch));
+      const tipHeaderEpoch = parseEpoch(BigInt(tipSinceValidationInfo.epoch));
+      const sinceHeaderEpoch = parseEpoch(
+        BigInt(cellSinceValidationInfo.epoch)
+      );
       const added = {
         number: BigInt(value.number + sinceHeaderEpoch.number),
         index:
@@ -168,18 +164,22 @@ function validateSince(
       );
     }
     if (type === "blockNumber") {
-      return value + BigInt(sinceHeader.number) <= BigInt(tipHeader.number);
+      return (
+        value + BigInt(cellSinceValidationInfo.block_number) <=
+        BigInt(tipSinceValidationInfo.block_number)
+      );
     }
     if (type === "blockTimestamp") {
-      if (!tipMedianTimestamp || !cellMedianTimestamp) {
-        throw new Error(
-          `Must provide tipMediamTimestamp and cellMedianTimestamp!`
-        );
+      if (
+        !tipSinceValidationInfo.median_timestamp ||
+        !cellSinceValidationInfo.median_timestamp
+      ) {
+        throw new Error(`Must provide median_timestamp!`);
       }
 
       return (
-        value * 1000n + BigInt(cellMedianTimestamp) <=
-        BigInt(tipMedianTimestamp)
+        value * 1000n + BigInt(cellSinceValidationInfo.median_timestamp) <=
+        BigInt(tipSinceValidationInfo.median_timestamp)
       );
     }
   }

--- a/packages/base/tests/since.test.js
+++ b/packages/base/tests/since.test.js
@@ -189,23 +189,15 @@ test("validateSince, absolute blockTimestamp", (t) => {
   });
 
   const sinceHeader = {
-    timestamp: "0x" + BigInt(+new Date("2020-01-01")).toString(16),
+    // timestamp: "0x" + BigInt(+new Date("2020-01-01")).toString(16),
   };
 
-  t.true(
-    validateSince(
-      since,
-      { timestamp: "0x" + (timestamp * 1000n).toString(16) },
-      sinceHeader
-    )
-  );
-  t.false(
-    validateSince(
-      since,
-      { timestamp: "0x" + (timestamp * 1000n - 1n).toString(16) },
-      sinceHeader
-    )
-  );
+  const validTipMedianTimestamp = "0x" + (timestamp * 1000n).toString(16);
+  const invalidTipMedianTimestamp =
+    "0x" + (timestamp * 1000n - 1n).toString(16);
+
+  t.true(validateSince(since, {}, sinceHeader, validTipMedianTimestamp));
+  t.false(validateSince(since, {}, sinceHeader, invalidTipMedianTimestamp));
 });
 
 test("validateSince, relative blockTimestamp", (t) => {
@@ -217,27 +209,32 @@ test("validateSince, relative blockTimestamp", (t) => {
   });
 
   const sinceHeader = {
-    timestamp: BigInt(+new Date("2020-01-01")),
+    // timestamp: BigInt(+new Date("2020-01-01")),
   };
+
+  const cellMedianTimestamp =
+    "0x" + BigInt(+new Date("2020-01-01")).toString(16);
+  const validTipMedianTimestamp =
+    "0x" + (BigInt(cellMedianTimestamp) + timestamp * 1000n).toString(16);
+  const invalidTipMedianTimestamp =
+    "0x" + (BigInt(cellMedianTimestamp) + timestamp * 1000n - 1n).toString(16);
 
   t.true(
     validateSince(
       since,
-      {
-        timestamp:
-          "0x" + (sinceHeader.timestamp + timestamp * 1000n).toString(16),
-      },
-      sinceHeader
+      {},
+      sinceHeader,
+      validTipMedianTimestamp,
+      cellMedianTimestamp
     )
   );
   t.false(
     validateSince(
       since,
-      {
-        timestamp:
-          "0x" + (sinceHeader.timestamp + timestamp * 1000n - 1n).toString(16),
-      },
-      sinceHeader
+      {},
+      sinceHeader,
+      invalidTipMedianTimestamp,
+      cellMedianTimestamp
     )
   );
 });

--- a/packages/base/tests/since.test.js
+++ b/packages/base/tests/since.test.js
@@ -133,22 +133,22 @@ test("validateSince, absolute blockNumber", (t) => {
     value: BigInt("12345"),
   });
 
-  const sinceHeader = {
+  const cellSinceValidationInfo = {
     number: "0x" + BigInt(11).toString(16),
   };
 
   t.true(
     validateSince(
       since,
-      { number: "0x" + BigInt(12345).toString(16) },
-      sinceHeader
+      { block_number: "0x" + BigInt(12345).toString(16) },
+      cellSinceValidationInfo
     )
   );
   t.false(
     validateSince(
       since,
-      { number: "0x" + BigInt(12345 - 1).toString(16) },
-      sinceHeader
+      { block_number: "0x" + BigInt(12345 - 1).toString(16) },
+      cellSinceValidationInfo
     )
   );
 });
@@ -160,22 +160,22 @@ test("validateSince, relative blockNumber", (t) => {
     value: BigInt("12345"),
   });
 
-  const sinceHeader = {
-    number: "0x" + BigInt(11).toString(16),
+  const cellSinceValidationInfo = {
+    block_number: "0x" + BigInt(11).toString(16),
   };
 
   t.true(
     validateSince(
       since,
-      { number: "0x" + BigInt(11 + 12345).toString(16) },
-      sinceHeader
+      { block_number: "0x" + BigInt(11 + 12345).toString(16) },
+      cellSinceValidationInfo
     )
   );
   t.false(
     validateSince(
       since,
-      { number: "0x" + BigInt(11 + 12345 - 1).toString(16) },
-      sinceHeader
+      { block_number: "0x" + BigInt(11 + 12345 - 1).toString(16) },
+      cellSinceValidationInfo
     )
   );
 });
@@ -188,7 +188,7 @@ test("validateSince, absolute blockTimestamp", (t) => {
     value: timestamp,
   });
 
-  const sinceHeader = {
+  const cellSinceValidationInfo = {
     // timestamp: "0x" + BigInt(+new Date("2020-01-01")).toString(16),
   };
 
@@ -196,8 +196,20 @@ test("validateSince, absolute blockTimestamp", (t) => {
   const invalidTipMedianTimestamp =
     "0x" + (timestamp * 1000n - 1n).toString(16);
 
-  t.true(validateSince(since, {}, sinceHeader, validTipMedianTimestamp));
-  t.false(validateSince(since, {}, sinceHeader, invalidTipMedianTimestamp));
+  t.true(
+    validateSince(
+      since,
+      { median_timestamp: validTipMedianTimestamp },
+      cellSinceValidationInfo
+    )
+  );
+  t.false(
+    validateSince(
+      since,
+      { median_timestamp: invalidTipMedianTimestamp },
+      cellSinceValidationInfo
+    )
+  );
 });
 
 test("validateSince, relative blockTimestamp", (t) => {
@@ -208,12 +220,13 @@ test("validateSince, relative blockTimestamp", (t) => {
     value: timestamp,
   });
 
-  const sinceHeader = {
-    // timestamp: BigInt(+new Date("2020-01-01")),
-  };
-
   const cellMedianTimestamp =
     "0x" + BigInt(+new Date("2020-01-01")).toString(16);
+
+  const cellSinceValidationInfo = {
+    median_timestamp: cellMedianTimestamp,
+  };
+
   const validTipMedianTimestamp =
     "0x" + (BigInt(cellMedianTimestamp) + timestamp * 1000n).toString(16);
   const invalidTipMedianTimestamp =
@@ -222,19 +235,15 @@ test("validateSince, relative blockTimestamp", (t) => {
   t.true(
     validateSince(
       since,
-      {},
-      sinceHeader,
-      validTipMedianTimestamp,
-      cellMedianTimestamp
+      { median_timestamp: validTipMedianTimestamp },
+      cellSinceValidationInfo
     )
   );
   t.false(
     validateSince(
       since,
-      {},
-      sinceHeader,
-      invalidTipMedianTimestamp,
-      cellMedianTimestamp
+      { median_timestamp: invalidTipMedianTimestamp },
+      cellSinceValidationInfo
     )
   );
 });
@@ -251,7 +260,7 @@ test("validateSince, absolute epochNumber", (t) => {
     value: value,
   });
 
-  const sinceHeader = {
+  const cellSinceValidationInfo = {
     epoch: generateHeaderEpoch({
       number: 1000,
       index: 0,
@@ -260,7 +269,11 @@ test("validateSince, absolute epochNumber", (t) => {
   };
 
   t.true(
-    validateSince(since, { epoch: generateHeaderEpoch(value) }, sinceHeader)
+    validateSince(
+      since,
+      { epoch: generateHeaderEpoch(value) },
+      cellSinceValidationInfo
+    )
   );
   t.false(
     validateSince(
@@ -272,7 +285,7 @@ test("validateSince, absolute epochNumber", (t) => {
           index: 1799,
         }),
       },
-      sinceHeader
+      cellSinceValidationInfo
     )
   );
 });
@@ -289,7 +302,7 @@ test("validateSince, relative epochNumber", (t) => {
     value: value,
   });
 
-  const sinceHeader = {
+  const cellSinceValidationInfo = {
     epoch: generateHeaderEpoch({
       number: 1000,
       index: 0,
@@ -307,7 +320,7 @@ test("validateSince, relative epochNumber", (t) => {
           index: 0,
         }),
       },
-      sinceHeader
+      cellSinceValidationInfo
     )
   );
   t.false(
@@ -320,7 +333,7 @@ test("validateSince, relative epochNumber", (t) => {
           index: 1799,
         }),
       },
-      sinceHeader
+      cellSinceValidationInfo
     )
   );
 });

--- a/packages/common-scripts/src/index.ts
+++ b/packages/common-scripts/src/index.ts
@@ -2,7 +2,7 @@ import secp256k1Blake160 from "./secp256k1_blake160";
 import secp256k1Blake160Multisig from "./secp256k1_blake160_multisig";
 import { MultisigScript, FromInfo } from "./from_info";
 import dao from "./dao";
-import locktimePool, { SinceBaseValue, LocktimeCell } from "./locktime_pool";
+import locktimePool, { LocktimeCell } from "./locktime_pool";
 import common, { LockScriptInfo } from "./common";
 import sudt from "./sudt";
 import anyoneCanPay from "./anyone_can_pay";
@@ -14,7 +14,6 @@ export {
   dao,
   locktimePool,
   common,
-  SinceBaseValue,
   LocktimeCell,
   MultisigScript,
   FromInfo,

--- a/packages/common-scripts/src/locktime_pool.ts
+++ b/packages/common-scripts/src/locktime_pool.ts
@@ -22,6 +22,7 @@ import {
   Header,
   QueryOptions,
   CellCollector as CellCollectorType,
+  SinceValidationInfo,
 } from "@ckb-lumos/base";
 const { toBigUInt64LE, readBigUInt64LE } = utils;
 const { ScriptValue } = values;
@@ -45,17 +46,11 @@ import { List, Set } from "immutable";
 import { getConfig, Config } from "@ckb-lumos/config-manager";
 import { secp256k1Blake160Multisig } from ".";
 
-export interface SinceBaseValue {
-  epoch: HexString;
-  number: HexString;
-  timestamp: HexString;
-}
-
 export interface LocktimeCell extends Cell {
   since: PackedSince;
   depositBlockHash?: Hash;
   withdrawBlockHash?: Hash;
-  sinceBaseValue?: SinceBaseValue;
+  sinceValidationInfo?: SinceValidationInfo;
 }
 
 export class CellCollector implements CellCollectorType {
@@ -63,6 +58,7 @@ export class CellCollector implements CellCollectorType {
   private config: Config;
   private rpc: RPC;
   private tipHeader?: Header;
+  private tipSinceValidationInfo?: SinceValidationInfo;
   public readonly fromScript: Script;
   public readonly multisigScript?: HexString;
 
@@ -91,6 +87,15 @@ export class CellCollector implements CellCollectorType {
 
     this.config = config;
     this.tipHeader = tipHeader;
+
+    if (tipHeader) {
+      // TODO: `median_timestamp` is not provided now!
+      this.tipSinceValidationInfo = {
+        block_number: tipHeader.number,
+        epoch: tipHeader.epoch,
+        median_timestamp: "",
+      };
+    }
 
     this.rpc = new NodeRPC(cellProvider.uri!);
 
@@ -165,16 +170,17 @@ export class CellCollector implements CellCollectorType {
         let maximumCapacity: bigint | undefined;
         let depositBlockHash: Hash | undefined;
         let withdrawBlockHash: Hash | undefined;
-        let sinceBaseValue: SinceBaseValue | undefined;
+        let sinceValidationInfo: SinceValidationInfo | undefined;
 
         // multisig
         if (lock.args.length === 58) {
           const header = await this.rpc.get_header(inputCell.block_hash);
           since = "0x" + _parseMultisigArgsSince(lock.args).toString(16);
-          sinceBaseValue = {
+          // TODO: `median_timestamp` not provided now!
+          sinceValidationInfo = {
             epoch: header.epoch,
-            number: header.number,
-            timestamp: header.timestamp,
+            block_number: header.number,
+            median_timestamp: "",
           };
         }
 
@@ -248,8 +254,13 @@ export class CellCollector implements CellCollectorType {
         }
 
         if (
-          this.tipHeader &&
-          !validateSince(since!, this.tipHeader, sinceBaseValue as Header)
+          parseSince(since!).type === "blockTimestamp" ||
+          (this.tipHeader &&
+            !validateSince(
+              since!,
+              this.tipSinceValidationInfo!,
+              sinceValidationInfo
+            ))
         ) {
           continue;
         }
@@ -259,7 +270,7 @@ export class CellCollector implements CellCollectorType {
           since: since!,
           depositBlockHash: depositBlockHash,
           withdrawBlockHash: withdrawBlockHash,
-          sinceBaseValue,
+          sinceValidationInfo,
         };
         result.cell_output.capacity =
           "0x" +

--- a/packages/common-scripts/tests/inputs.ts
+++ b/packages/common-scripts/tests/inputs.ts
@@ -203,7 +203,7 @@ export const bobMultisigLockSudtInputs: LocktimeCell[] = [
     since: "0x0",
     depositBlockHash: undefined,
     withdrawBlockHash: undefined,
-    sinceBaseValue: undefined,
+    sinceValidationInfo: undefined,
   },
 ];
 


### PR DESCRIPTION
* Fix `validateSince` `type=blockTimestamp` validation
* Refactor `validateSince` interface, replace `Header` params with `SinceValidationInfo`, which includes `block_number`, `epoch` and `median_timestamp` (BREAKING CHANGE)
* Skip cells which since type equals `blockTimestamp` in `LocktimePool#cellCollector`
* Replace `sinceBaseValue` with `sinceValidationInfo` in `LocktimeCell` (BREAKING CHANGE)