### PR TITLE
Feature: Remove CPU restrictions where its not necessary.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "cpu": ["x64"],
   "os": ["win32", "darwin", "linux"],
   "devDependencies": {
     "@ava/typescript": "^1.1.1",

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -10,9 +10,6 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "cpu": [
-    "x64"
-  ],
   "os": [
     "win32",
     "darwin",

--- a/packages/common-scripts/package.json
+++ b/packages/common-scripts/package.json
@@ -10,9 +10,6 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "cpu": [
-    "x64"
-  ],
   "os": [
     "win32",
     "darwin",

--- a/packages/config-manager/package.json
+++ b/packages/config-manager/package.json
@@ -10,9 +10,6 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "cpu": [
-    "x64"
-  ],
   "os": [
     "win32",
     "darwin",

--- a/packages/hd/package.json
+++ b/packages/hd/package.json
@@ -10,9 +10,6 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "cpu": [
-    "x64"
-  ],
   "os": [
     "win32",
     "darwin",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -10,9 +10,6 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "cpu": [
-    "x64"
-  ],
   "os": [
     "win32",
     "darwin",

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -10,9 +10,6 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "cpu": [
-    "x64"
-  ],
   "os": [
     "win32",
     "darwin",


### PR DESCRIPTION
Some packages that don't rely on ckb-lumos/indexer dependency or sql-indexer don't need to be CPU restricted. Some of them contain almost exclusively TypeScript/JavaScript code. It will run on arm64 for sure.

Working godwoken-examples deposit to layer 2 on Mac M1 which relies on ckb-lumos/base and other packages (using this branch feat/arm64):

<img width="1801" alt="Screenshot 2021-08-18 181932" src="https://user-images.githubusercontent.com/4950658/129934728-a7d31d5c-48ad-4808-a744-b7d5a1e451ae.png">

---

How I tested this:

1. Use Node v14
2. Clone and build kuzirashi:feat/arm64 on M1 machine (with indexer, sql-indexer, hd-cache, transaction-manager removed locally - because it won't build on arm64).
3. Clone kuzirashi/godwoken-examples and change all references to ckb-lumos packages to built locally kuzirashi/lumos:feat/arm64
4. Run deposit command.

Result: works.

Note: I think removing indexer, sql-indexer, hd-cache, transaction-manager locally just to build it on Mac M1 doesn't affect tests because these are build on Linux in Continuous Integration so it won't be event part of the process after we merge this pull request. I didn't want to publish trash packages just for testing to NPM.

Please review @bitrocks @classicalliu. 🙏 
