### PR TITLE
feat: supported new full address format

### DIFF
--- a/packages/base/index.d.ts
+++ b/packages/base/index.d.ts
@@ -33,7 +33,7 @@ export interface Header {
   version: HexNumber;
 }
 
-export type HashType = "type" | "data";
+export type HashType = "type" | "data" | "data1";
 export interface Script {
   code_hash: Hash;
   hash_type: HashType;

--- a/packages/base/lib/denormalizers.js
+++ b/packages/base/lib/denormalizers.js
@@ -9,9 +9,15 @@ function DenormalizeOutPoint(outPoint) {
 }
 
 function DenormalizeScript(script) {
+  const hashType = script.getHashType();
+
   return {
     code_hash: new Reader(script.getCodeHash().raw()).serializeJson(),
-    hash_type: script.getHashType() === 0 ? "data" : "type",
+    hash_type: (() => {
+      if (hashType === 0) return "data";
+      if (hashType === 1) return "type";
+      if (hashType === 2) return "data1";
+    })(),
     args: new Reader(script.getArgs().raw()).serializeJson(),
   };
 }

--- a/packages/base/lib/utils.js
+++ b/packages/base/lib/utils.js
@@ -48,7 +48,10 @@ function readBigUInt64LE(hex) {
 }
 
 const U128_MIN = BigInt(0);
-const U128_MAX = BigInt(2) ** BigInt(128) - BigInt(1);
+// create-react-app@4.0.3 default config will transform `**` to `Math.pow`.
+// However, Math.pow(BigInt(), BigInt()) will cause an error
+// const U128_MAX = BigInt(2) ** BigInt(128) - BigInt(1);
+const U128_MAX = 340282366920938463463374607431768211455n;
 function toBigUInt128LE(u128) {
   if (u128 < U128_MIN) {
     throw new Error(`u128 ${u128} too small`);

--- a/packages/common-scripts/src/common.ts
+++ b/packages/common-scripts/src/common.ts
@@ -21,6 +21,7 @@ import {
   PackedSince,
   utils,
   Transaction,
+  HashType,
 } from "@ckb-lumos/base";
 import anyoneCanPay from "./anyone_can_pay";
 const { ScriptValue } = values;
@@ -40,7 +41,7 @@ function defaultLogger(level: string, message: string) {
  */
 export interface LockScriptInfo {
   code_hash: Hash;
-  hash_type: "type" | "data";
+  hash_type: HashType;
   lockScriptInfo: {
     CellCollector: any;
     setupInputCell(

--- a/packages/config-manager/index.d.ts
+++ b/packages/config-manager/index.d.ts
@@ -9,13 +9,16 @@ export interface ScriptConfig {
   SHORT_ID?: number;
 }
 
-export interface ScriptConfigs {
-  [field: string]: ScriptConfig | undefined;
+export interface PredefinedScriptConfigs {
   ANYONE_CAN_PAY?: ScriptConfig;
   SUDT?: ScriptConfig;
   DAO?: ScriptConfig;
   SECP256K1_BLAKE160_MULTISIG?: ScriptConfig;
   SECP256K1_BLAKE160?: ScriptConfig;
+}
+
+export interface ScriptConfigs extends PredefinedScriptConfigs {
+  [field: string]: ScriptConfig | undefined;
 }
 
 /**

--- a/packages/config-manager/index.d.ts
+++ b/packages/config-manager/index.d.ts
@@ -1,7 +1,7 @@
 /** Deployed script on chain */
 export interface ScriptConfig {
   CODE_HASH: string;
-  HASH_TYPE: "type" | "data";
+  HASH_TYPE: "type" | "data" | "data1";
   TX_HASH: string;
   INDEX: string;
   DEP_TYPE: "dep_group" | "code";
@@ -11,6 +11,11 @@ export interface ScriptConfig {
 
 export interface ScriptConfigs {
   [field: string]: ScriptConfig | undefined;
+  ANYONE_CAN_PAY?: ScriptConfig;
+  SUDT?: ScriptConfig;
+  DAO?: ScriptConfig;
+  SECP256K1_BLAKE160_MULTISIG?: ScriptConfig;
+  SECP256K1_BLAKE160?: ScriptConfig;
 }
 
 /**
@@ -18,6 +23,7 @@ export interface ScriptConfigs {
  * own address prefix, and its own set of deployed scripts.
  */
 export interface Config {
+  CKB2021?: boolean;
   PREFIX: string;
   SCRIPTS: ScriptConfigs;
 }
@@ -44,4 +50,9 @@ export function initializeConfig(): void;
 export const predefined: {
   LINA: Config;
   AGGRON4: Config;
+  CKB2019: typeof CKB2019;
+  CKB2021: typeof CKB2021;
 };
+
+declare function CKB2019(config: Config): Config;
+declare function CKB2021(config: Config): Config;

--- a/packages/config-manager/index.d.ts
+++ b/packages/config-manager/index.d.ts
@@ -50,9 +50,7 @@ export function initializeConfig(): void;
 export const predefined: {
   LINA: Config;
   AGGRON4: Config;
-  CKB2019: typeof CKB2019;
-  CKB2021: typeof CKB2021;
 };
 
-declare function CKB2019(config: Config): Config;
-declare function CKB2021(config: Config): Config;
+export function CKB2019(config: Config): Config;
+export function CKB2021(config: Config): Config;

--- a/packages/config-manager/lib/index.js
+++ b/packages/config-manager/lib/index.js
@@ -78,9 +78,25 @@ function initializeConfig() {
   }
 }
 
+function CKB2019(config) {
+  return {
+    ...config,
+    CKB2021: false,
+  };
+}
+
+function CKB2021(config) {
+  return {
+    ...config,
+    CKB2021: true,
+  };
+}
+
 module.exports = {
   getConfig,
   initializeConfig,
   predefined,
   validateConfig,
+  CKB2019,
+  CKB2021,
 };

--- a/packages/config-manager/lib/predefined.js
+++ b/packages/config-manager/lib/predefined.js
@@ -108,23 +108,7 @@ const AGGRON4 = deepFreeze({
   },
 });
 
-function CKB2019(config) {
-  return {
-    ...config,
-    CKB2021: false,
-  };
-}
-
-function CKB2021(config) {
-  return {
-    ...config,
-    CKB2021: true,
-  };
-}
-
 module.exports = {
   LINA,
   AGGRON4,
-  CKB2019,
-  CKB2021,
 };

--- a/packages/config-manager/lib/predefined.js
+++ b/packages/config-manager/lib/predefined.js
@@ -1,6 +1,7 @@
 const deepFreeze = require("deep-freeze-strict");
 
 const LINA = deepFreeze({
+  CKB2021: true,
   PREFIX: "ckb",
   SCRIPTS: {
     SECP256K1_BLAKE160: {
@@ -54,6 +55,7 @@ const LINA = deepFreeze({
 });
 
 const AGGRON4 = deepFreeze({
+  CKB2021: true,
   PREFIX: "ckt",
   SCRIPTS: {
     SECP256K1_BLAKE160: {
@@ -106,7 +108,23 @@ const AGGRON4 = deepFreeze({
   },
 });
 
+function CKB2019(config) {
+  return {
+    ...config,
+    CKB2021: false,
+  };
+}
+
+function CKB2021(config) {
+  return {
+    ...config,
+    CKB2021: true,
+  };
+}
+
 module.exports = {
   LINA,
   AGGRON4,
+  CKB2019,
+  CKB2021,
 };

--- a/packages/config-manager/lib/predefined.js
+++ b/packages/config-manager/lib/predefined.js
@@ -50,6 +50,7 @@ const LINA = deepFreeze({
         "0x4153a2014952d7cac45f285ce9a7c5c0c0e1b21f2d378b82ac1433cb11c25c4d",
       INDEX: "0x0",
       DEP_TYPE: "dep_group",
+      SHORT_ID: 2,
     },
   },
 });
@@ -104,6 +105,7 @@ const AGGRON4 = deepFreeze({
         "0xec26b0f85ed839ece5f11c4c4e837ec359f5adc4420410f6453b1f6b60fb96a6",
       INDEX: "0x0",
       DEP_TYPE: "dep_group",
+      SHORT_ID: 2,
     },
   },
 });

--- a/packages/hd-cache/src/index.ts
+++ b/packages/hd-cache/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  HashType,
   HexString,
   Script,
   Cell,
@@ -49,7 +50,7 @@ interface LockScriptInfo {
 
 export interface LockScriptMappingInfo {
   code_hash: HexString;
-  hash_type: "data" | "type";
+  hash_type: HashType;
   publicKeyToArgs: (publicKey: HexString) => HexString;
 }
 

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@ckb-lumos/base": "^0.18.0-rc1",
     "@ckb-lumos/config-manager": "^0.18.0-rc1",
-    "bech32": "^1.1.4",
+    "bech32": "^2.0.0",
     "ckb-js-toolkit": "^0.10.2",
     "immutable": "^4.0.0-rc.12"
   },

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -99,10 +99,6 @@ export function generateAddress(
   if (scriptTemplate && scriptTemplate.SHORT_ID !== undefined) {
     data.push(1, scriptTemplate.SHORT_ID);
     data.push(...hexToByteArray(script.args));
-
-    if (config.CKB2021) {
-      return bech32m.encode(config.PREFIX, bech32m.toWords(data), BECH32_LIMIT);
-    }
   } else if (config.CKB2021) {
     const hash_type = (() => {
       if (script.hash_type === "data") return 0;
@@ -116,7 +112,7 @@ export function generateAddress(
     data.push(...hexToByteArray(script.code_hash));
     data.push(hash_type);
     data.push(...hexToByteArray(script.args));
-    console.log("CKB2021!!!!!");
+
     return bech32m.encode(config.PREFIX, bech32m.toWords(data), BECH32_LIMIT);
   } else {
     data.push(script.hash_type === "type" ? 4 : 2);

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -11,7 +11,7 @@ import {
   Transaction,
   WitnessArgs,
 } from "@ckb-lumos/base";
-import * as bech32 from "bech32";
+import { bech32, bech32m } from "bech32";
 import { normalizers, validators, Reader } from "ckb-js-toolkit";
 import { List, Record, Map as ImmutableMap } from "immutable";
 import { getConfig, Config } from "@ckb-lumos/config-manager";
@@ -95,10 +95,29 @@ export function generateAddress(
     (s) =>
       s!.CODE_HASH === script.code_hash && s!.HASH_TYPE === script.hash_type
   );
-  const data = [];
+  const data: number[] = [];
   if (scriptTemplate && scriptTemplate.SHORT_ID !== undefined) {
     data.push(1, scriptTemplate.SHORT_ID);
     data.push(...hexToByteArray(script.args));
+
+    if (config.CKB2021) {
+      return bech32m.encode(config.PREFIX, bech32m.toWords(data), BECH32_LIMIT);
+    }
+  } else if (config.CKB2021) {
+    const hash_type = (() => {
+      if (script.hash_type === "data") return 0;
+      if (script.hash_type === "type") return 1;
+      if (script.hash_type === "data1") return 2;
+
+      throw new Error(`unknown hash_type ${script.hash_type}`);
+    })();
+
+    data.push(0x00);
+    data.push(...hexToByteArray(script.code_hash));
+    data.push(hash_type);
+    data.push(...hexToByteArray(script.args));
+    console.log("CKB2021!!!!!");
+    return bech32m.encode(config.PREFIX, bech32m.toWords(data), BECH32_LIMIT);
   } else {
     data.push(script.hash_type === "type" ? 4 : 2);
     data.push(...hexToByteArray(script.code_hash));
@@ -142,19 +161,57 @@ export function generateSecp256k1Blake160MultisigAddress(
   });
 }
 
+function trySeries<T extends (...args: unknown[]) => unknown>(
+  ...fns: T[]
+): ReturnType<T> {
+  let latestCatch: unknown;
+  for (let fn of fns) {
+    try {
+      return fn() as ReturnType<T>;
+    } catch (e) {
+      latestCatch = e;
+    }
+  }
+  throw latestCatch;
+}
+
 export function parseAddress(
   address: Address,
   { config = undefined }: Options = {}
 ): Script {
   config = config || getConfig();
-  const { prefix, words } = bech32.decode(address, BECH32_LIMIT);
+  const { prefix, words } = trySeries(
+    () => bech32.decode(address, BECH32_LIMIT),
+    () => bech32m.decode(address, BECH32_LIMIT)
+  );
   if (prefix !== config.PREFIX) {
     throw Error(
       `Invalid prefix! Expected: ${config.PREFIX}, actual: ${prefix}`
     );
   }
-  const data = bech32.fromWords(words);
+  const data = trySeries(
+    () => bech32.fromWords(words),
+    () => bech32m.fromWords(words)
+  );
   switch (data[0]) {
+    case 0:
+      //  1 +   32     +    1
+      // 00  code_hash  hash_type
+      if (data.length < 34) {
+        throw new Error(`Invalid payload length!`);
+      }
+      const serializedHashType = data.slice(33, 34)[0];
+      return {
+        code_hash: byteArrayToHex(data.slice(1, 33)),
+        hash_type: (() => {
+          if (serializedHashType === 0) return "data" as const;
+          if (serializedHashType === 1) return "type" as const;
+          if (serializedHashType === 2) return "data1" as const;
+
+          throw new Error(`unknown hash_type ${serializedHashType}`);
+        })(),
+        args: byteArrayToHex(data.slice(34)),
+      };
     case 1:
       if (data.length < 2) {
         throw Error(`Invalid payload length!`);

--- a/packages/helpers/tests/generate_address.test.ts
+++ b/packages/helpers/tests/generate_address.test.ts
@@ -5,10 +5,10 @@ import {
   generateSecp256k1Blake160MultisigAddress,
   scriptToAddress,
 } from "../src";
-import { predefined } from "@ckb-lumos/config-manager";
+import { predefined, CKB2019 } from "@ckb-lumos/config-manager";
 
-const LINA = predefined.CKB2019(predefined.LINA);
-const AGGRON4 = predefined.CKB2019(predefined.AGGRON4);
+const LINA = CKB2019(predefined.LINA);
+const AGGRON4 = CKB2019(predefined.AGGRON4);
 
 import {
   shortAddressInfo,

--- a/packages/helpers/tests/generate_address.test.ts
+++ b/packages/helpers/tests/generate_address.test.ts
@@ -6,7 +6,10 @@ import {
   scriptToAddress,
 } from "../src";
 import { predefined } from "@ckb-lumos/config-manager";
-const { LINA, AGGRON4 } = predefined;
+
+const LINA = predefined.CKB2019(predefined.LINA);
+const AGGRON4 = predefined.CKB2019(predefined.AGGRON4);
+
 import {
   shortAddressInfo,
   multisigAddressInfo,

--- a/packages/helpers/tests/generate_address_ckb2021.test.ts
+++ b/packages/helpers/tests/generate_address_ckb2021.test.ts
@@ -1,51 +1,167 @@
 import test from "ava";
 import { generateAddress } from "../src";
-import { predefined, ScriptConfig, CKB2019 } from "@ckb-lumos/config-manager";
-import { Script } from "@ckb-lumos/base";
+import {
+  CKB2021,
+  Config,
+  predefined,
+  PredefinedScriptConfigs,
+} from "@ckb-lumos/config-manager";
+import { Script, HashType } from "@ckb-lumos/base";
 
-const LINA = CKB2019(predefined.LINA);
+const LINA = CKB2021(predefined.LINA);
+const AGGRON4 = CKB2021(predefined.AGGRON4);
 
-function ScriptFrom(config: ScriptConfig, args: string): Script {
+type NetworkType = keyof typeof predefined;
+type ScriptName = keyof PredefinedScriptConfigs;
+
+function ScriptFrom(
+  scriptName: ScriptName,
+  args: string,
+  hash_type?: HashType
+): { LINA: Script; AGGRON4: Script } {
   return {
-    hash_type: config.HASH_TYPE,
-    code_hash: config.CODE_HASH,
-    args,
+    LINA: {
+      code_hash: LINA.SCRIPTS[scriptName]!.CODE_HASH,
+      hash_type: hash_type || LINA.SCRIPTS[scriptName]!.HASH_TYPE,
+      args,
+    },
+    AGGRON4: {
+      code_hash: AGGRON4.SCRIPTS[scriptName]!.CODE_HASH,
+      hash_type: hash_type || AGGRON4.SCRIPTS[scriptName]!.HASH_TYPE,
+      args,
+    },
   };
 }
 
-test("test ckb2021 short generateAddress 00", (t) => {
-  const address = generateAddress(
-    ScriptFrom(
-      LINA.SCRIPTS.SECP256K1_BLAKE160!,
-      "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64"
-    ),
-    {
-      config: LINA,
-    }
-  );
+function ConfigFrom(
+  networkType: NetworkType,
+  options: { excludeShortId?: boolean } = {}
+): Config {
+  const { excludeShortId = false } = options;
+  const config = predefined[networkType];
+  return {
+    ...config,
+    SCRIPTS: excludeShortId ? {} : config.SCRIPTS,
+  };
+}
 
-  t.is(address, "ckb1qyqt8xaupvm8837nv3gtc9x0ekkj64vud3jqfwyw5v");
-});
-
-test("test CKB2021 full generateAddress", (t) => {
-  const address = generateAddress(
-    {
-      code_hash:
-        "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-      hash_type: "type",
-      args: "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64",
-    },
-    {
-      config: {
-        CKB2021: true,
-        PREFIX: "ckb",
-        SCRIPTS: {},
-      },
-    }
+test("default short address (code_hash_index = 0x00)", (t) => {
+  const script = ScriptFrom(
+    "SECP256K1_BLAKE160",
+    "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64"
   );
 
   t.is(
-    address,
-    "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqdnnw7qkdnnclfkg59uzn8umtfd2kwxceqxwquc4"
+    generateAddress(script.LINA, { config: ConfigFrom("LINA") }),
+    "ckb1qyqt8xaupvm8837nv3gtc9x0ekkj64vud3jqfwyw5v"
+  );
+
+  t.is(
+    generateAddress(script.AGGRON4, { config: ConfigFrom("AGGRON4") }),
+    "ckt1qyqt8xaupvm8837nv3gtc9x0ekkj64vud3jq5t63cs"
   );
 });
+
+test("multisign short address (code_hash_index = 0x01)", (t) => {
+  const script = ScriptFrom(
+    "SECP256K1_BLAKE160_MULTISIG",
+    "0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a"
+  );
+
+  t.is(
+    generateAddress(script.LINA, { config: ConfigFrom("LINA") }),
+    "ckb1qyq5lv479ewscx3ms620sv34pgeuz6zagaaqklhtgg"
+  );
+
+  t.is(
+    generateAddress(script.AGGRON4, { config: ConfigFrom("AGGRON4") }),
+    "ckt1qyq5lv479ewscx3ms620sv34pgeuz6zagaaqt6f5y5"
+  );
+});
+
+test("acp short address (code_hash_index = 0x02)", (t) => {
+  const script = ScriptFrom(
+    "ANYONE_CAN_PAY",
+    "0xbd07d9f32bce34d27152a6a0391d324f79aab854"
+  );
+
+  t.is(
+    generateAddress(script.LINA, { config: ConfigFrom("LINA") }),
+    "ckb1qypt6p7e7v4uudxjw9f2dgper5ey77d2hp2qxz4u4u"
+  );
+
+  t.is(
+    generateAddress(script.AGGRON4, { config: ConfigFrom("AGGRON4") }),
+    "ckt1qypt6p7e7v4uudxjw9f2dgper5ey77d2hp2qm8treq"
+  );
+});
+
+test("full address test (hash_type = 0x00)", (t) => {
+  const script: Script = {
+    code_hash:
+      "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+    hash_type: "data",
+    args: "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64",
+  };
+
+  t.is(
+    generateAddress(script, {
+      config: ConfigFrom("LINA", { excludeShortId: true }),
+    }),
+    "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq9nnw7qkdnnclfkg59uzn8umtfd2kwxceqvguktl"
+  );
+
+  t.is(
+    generateAddress(script, {
+      config: ConfigFrom("AGGRON4", { excludeShortId: true }),
+    }),
+    "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq9nnw7qkdnnclfkg59uzn8umtfd2kwxceqz6hep8"
+  );
+});
+
+test("full address test (hash_type = 0x01)", (t) => {
+  const script: Script = {
+    code_hash:
+      "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+    hash_type: "type",
+    args: "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64",
+  };
+
+  t.is(
+    generateAddress(script, {
+      config: ConfigFrom("LINA", { excludeShortId: true }),
+    }),
+    "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqdnnw7qkdnnclfkg59uzn8umtfd2kwxceqxwquc4"
+  );
+
+  t.is(
+    generateAddress(script, {
+      config: ConfigFrom("AGGRON4", { excludeShortId: true }),
+    }),
+    "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqdnnw7qkdnnclfkg59uzn8umtfd2kwxceqgutnjd"
+  );
+});
+
+test("full address test (hash_type = 0x02)", (t) => {
+  const script: Script = {
+    code_hash:
+      "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+    hash_type: "data1",
+    args: "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64",
+  };
+
+  t.is(
+    generateAddress(script, {
+      config: ConfigFrom("LINA", { excludeShortId: true }),
+    }),
+    "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq4nnw7qkdnnclfkg59uzn8umtfd2kwxceqcydzyt"
+  );
+
+  t.is(
+    generateAddress(script, {
+      config: ConfigFrom("AGGRON4", { excludeShortId: true }),
+    }),
+    "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq4nnw7qkdnnclfkg59uzn8umtfd2kwxceqkkxdwn"
+  );
+});
+

--- a/packages/helpers/tests/generate_address_ckb2021.test.ts
+++ b/packages/helpers/tests/generate_address_ckb2021.test.ts
@@ -1,0 +1,51 @@
+import test from "ava";
+import { generateAddress } from "../src";
+import { predefined, ScriptConfig } from "@ckb-lumos/config-manager";
+import { Script } from "@ckb-lumos/base";
+
+const LINA = predefined.CKB2019(predefined.LINA);
+
+function ScriptFrom(config: ScriptConfig, args: string): Script {
+  return {
+    hash_type: config.HASH_TYPE,
+    code_hash: config.CODE_HASH,
+    args,
+  };
+}
+
+test("test ckb2021 short generateAddress 00", (t) => {
+  const address = generateAddress(
+    ScriptFrom(
+      LINA.SCRIPTS.SECP256K1_BLAKE160!,
+      "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64"
+    ),
+    {
+      config: LINA,
+    }
+  );
+
+  t.is(address, "ckb1qyqt8xaupvm8837nv3gtc9x0ekkj64vud3jqfwyw5v");
+});
+
+test("test CKB2021 full generateAddress", (t) => {
+  const address = generateAddress(
+    {
+      code_hash:
+        "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+      hash_type: "type",
+      args: "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64",
+    },
+    {
+      config: {
+        CKB2021: true,
+        PREFIX: "ckb",
+        SCRIPTS: {},
+      },
+    }
+  );
+
+  t.is(
+    address,
+    "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqdnnw7qkdnnclfkg59uzn8umtfd2kwxceqxwquc4"
+  );
+});

--- a/packages/helpers/tests/generate_address_ckb2021.test.ts
+++ b/packages/helpers/tests/generate_address_ckb2021.test.ts
@@ -1,9 +1,9 @@
 import test from "ava";
 import { generateAddress } from "../src";
-import { predefined, ScriptConfig } from "@ckb-lumos/config-manager";
+import { predefined, ScriptConfig, CKB2019 } from "@ckb-lumos/config-manager";
 import { Script } from "@ckb-lumos/base";
 
-const LINA = predefined.CKB2019(predefined.LINA);
+const LINA = CKB2019(predefined.LINA);
 
 function ScriptFrom(config: ScriptConfig, args: string): Script {
   return {

--- a/packages/helpers/tests/generate_address_ckb2021.test.ts
+++ b/packages/helpers/tests/generate_address_ckb2021.test.ts
@@ -164,4 +164,3 @@ test("full address test (hash_type = 0x02)", (t) => {
     "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq4nnw7qkdnnclfkg59uzn8umtfd2kwxceqkkxdwn"
   );
 });
-

--- a/packages/helpers/tests/parse_address.test.ts
+++ b/packages/helpers/tests/parse_address.test.ts
@@ -5,10 +5,10 @@ import {
   multisigAddressInfo,
   fullAddressInfo,
 } from "./addresses";
-import { predefined } from "@ckb-lumos/config-manager";
+import { predefined, CKB2019 } from "@ckb-lumos/config-manager";
 
-const LINA = predefined.CKB2019(predefined.LINA);
-const AGGRON4 = predefined.CKB2019(predefined.AGGRON4);
+const LINA = CKB2019(predefined.LINA);
+const AGGRON4 = CKB2019(predefined.AGGRON4);
 
 test("short address, mainnet", (t) => {
   const script = parseAddress(shortAddressInfo.mainnetAddress, {

--- a/packages/helpers/tests/parse_address.test.ts
+++ b/packages/helpers/tests/parse_address.test.ts
@@ -5,10 +5,8 @@ import {
   multisigAddressInfo,
   fullAddressInfo,
 } from "./addresses";
-import { predefined, CKB2019 } from "@ckb-lumos/config-manager";
-
-const LINA = CKB2019(predefined.LINA);
-const AGGRON4 = CKB2019(predefined.AGGRON4);
+import { predefined } from "@ckb-lumos/config-manager";
+const { LINA, AGGRON4 } = predefined;
 
 test("short address, mainnet", (t) => {
   const script = parseAddress(shortAddressInfo.mainnetAddress, {

--- a/packages/helpers/tests/parse_address.test.ts
+++ b/packages/helpers/tests/parse_address.test.ts
@@ -6,7 +6,9 @@ import {
   fullAddressInfo,
 } from "./addresses";
 import { predefined } from "@ckb-lumos/config-manager";
-const { LINA, AGGRON4 } = predefined;
+
+const LINA = predefined.CKB2019(predefined.LINA);
+const AGGRON4 = predefined.CKB2019(predefined.AGGRON4);
 
 test("short address, mainnet", (t) => {
   const script = parseAddress(shortAddressInfo.mainnetAddress, {

--- a/packages/helpers/tests/parse_address_ckb2021.test.ts
+++ b/packages/helpers/tests/parse_address_ckb2021.test.ts
@@ -1,8 +1,8 @@
 import test from "ava";
 import { parseAddress } from "../src";
-import { predefined } from "@ckb-lumos/config-manager";
+import { predefined, CKB2021 } from "@ckb-lumos/config-manager";
 
-const LINA = predefined.CKB2021(predefined.LINA);
+const LINA = CKB2021(predefined.LINA);
 
 test("CKB2021 short address 00", (t) => {
   const script = parseAddress(

--- a/packages/helpers/tests/parse_address_ckb2021.test.ts
+++ b/packages/helpers/tests/parse_address_ckb2021.test.ts
@@ -1,0 +1,57 @@
+import test from "ava";
+import { parseAddress } from "../src";
+import { predefined } from "@ckb-lumos/config-manager";
+
+const LINA = predefined.CKB2021(predefined.LINA);
+
+test("CKB2021 short address 00", (t) => {
+  const script = parseAddress(
+    "ckb1qyqt8xaupvm8837nv3gtc9x0ekkj64vud3jqfwyw5v",
+    {
+      config: LINA,
+    }
+  );
+  t.deepEqual(script, {
+    code_hash: LINA.SCRIPTS.SECP256K1_BLAKE160!.CODE_HASH,
+    hash_type: LINA.SCRIPTS.SECP256K1_BLAKE160!.HASH_TYPE,
+    args: "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64",
+  });
+});
+
+test("CKB2021 short address 01", (t) => {
+  const script = parseAddress(
+    "ckb1qyq5lv479ewscx3ms620sv34pgeuz6zagaaqklhtgg",
+    {
+      config: LINA,
+    }
+  );
+  t.deepEqual(script, {
+    code_hash: LINA.SCRIPTS.SECP256K1_BLAKE160_MULTISIG!.CODE_HASH,
+    hash_type: LINA.SCRIPTS.SECP256K1_BLAKE160_MULTISIG!.HASH_TYPE,
+    args: "0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a",
+  });
+});
+
+test("CKB2021 full address", (t) => {
+  const script = parseAddress(
+    "ckb1qjda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xw3vumhs9nvu786dj9p0q5elx66t24n3kxgj53qks",
+    {
+      config: {
+        CKB2021: true,
+        PREFIX: "ckb",
+        SCRIPTS: {
+          ...LINA.SCRIPTS,
+          SECP256K1_BLAKE160: {
+            ...LINA.SCRIPTS.SECP256K1_BLAKE160!,
+            SHORT_ID: undefined,
+          },
+        },
+      },
+    }
+  );
+  t.deepEqual(script, {
+    code_hash: LINA.SCRIPTS.SECP256K1_BLAKE160!.CODE_HASH,
+    hash_type: LINA.SCRIPTS.SECP256K1_BLAKE160!.HASH_TYPE,
+    args: "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64",
+  });
+});

--- a/packages/helpers/tests/parse_address_ckb2021.test.ts
+++ b/packages/helpers/tests/parse_address_ckb2021.test.ts
@@ -1,8 +1,9 @@
 import test from "ava";
 import { parseAddress } from "../src";
-import { predefined, CKB2021 } from "@ckb-lumos/config-manager";
+import { predefined } from "@ckb-lumos/config-manager";
 
-const LINA = CKB2021(predefined.LINA);
+const LINA = predefined.LINA;
+const AGGRON = predefined.AGGRON4;
 
 test("CKB2021 short address 00", (t) => {
   const script = parseAddress(
@@ -36,22 +37,25 @@ test("CKB2021 full address", (t) => {
   const script = parseAddress(
     "ckb1qjda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xw3vumhs9nvu786dj9p0q5elx66t24n3kxgj53qks",
     {
-      config: {
-        CKB2021: true,
-        PREFIX: "ckb",
-        SCRIPTS: {
-          ...LINA.SCRIPTS,
-          SECP256K1_BLAKE160: {
-            ...LINA.SCRIPTS.SECP256K1_BLAKE160!,
-            SHORT_ID: undefined,
-          },
-        },
-      },
+      config: LINA,
     }
   );
   t.deepEqual(script, {
     code_hash: LINA.SCRIPTS.SECP256K1_BLAKE160!.CODE_HASH,
     hash_type: LINA.SCRIPTS.SECP256K1_BLAKE160!.HASH_TYPE,
+    args: "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64",
+  });
+});
+
+test("CKB2021 full address hash_type=0x02", (t) => {
+  const script = parseAddress(
+    "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq4nnw7qkdnnclfkg59uzn8umtfd2kwxceqkkxdwn",
+    { config: AGGRON }
+  );
+  t.deepEqual(script, {
+    code_hash:
+      "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+    hash_type: "data1",
     args: "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64",
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -591,10 +591,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bech32@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
-  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+bech32@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
+  integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
 
 binary-extensions@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR is adapted to CKB 2021 hardfork, it works for

- [supported `extra_hash`](https://github.com/nervosnetwork/ckb/pull/2776)
- [supported VM version selection](https://github.com/nervosnetwork/rfcs/blob/c0aacf775a347ec44b3b0c02ba6dd67a5a47128c/rfcs/0032-ckb-vm-version-selection/0032-ckb-vm-version-selection.md)
- [new full address format](https://github.com/nervosnetwork/rfcs/pull/239)

This PR is a supplement to #172