### PR TITLE
feat(helpers)!: deprecated short fmt address

### DIFF
--- a/packages/config-manager/src/types.ts
+++ b/packages/config-manager/src/types.ts
@@ -5,7 +5,11 @@ export interface ScriptConfig {
   TX_HASH: string;
   INDEX: string;
   DEP_TYPE: "dep_group" | "code";
-  /** Short ID for creating CKB address, not all scripts have short IDs. */
+  /**
+   * Short ID for creating CKB address, not all scripts have short IDs.
+   * @deprecated The short address will be removed in the future. If you need to generate short address,
+   *  please use the `generateAddress(script, { __generateShortAddressWhenShortIDInConfig: true })`
+   */
   SHORT_ID?: number;
 }
 

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -20,6 +20,10 @@ export interface Options {
   config?: Config;
 }
 
+export interface GenerateOptions extends Options {
+  __generateShortAddressWhenShortIDInConfig?: boolean;
+}
+
 const BECH32_LIMIT = 1023;
 
 function byteArrayToHex(a: number[]): HexString {
@@ -88,13 +92,18 @@ export function locateCellDep(
 
 export function generateAddress(
   script: Script,
-  { config = undefined }: Options = {}
+  {
+    config = undefined,
+    __generateShortAddressWhenShortIDInConfig = false,
+  }: GenerateOptions = {}
 ): Address {
   config = config || getConfig();
-  const scriptTemplate = Object.values(config.SCRIPTS).find(
-    (s) =>
-      s!.CODE_HASH === script.code_hash && s!.HASH_TYPE === script.hash_type
-  );
+  const scriptTemplate =
+    __generateShortAddressWhenShortIDInConfig &&
+    Object.values(config.SCRIPTS).find(
+      (s) =>
+        s!.CODE_HASH === script.code_hash && s!.HASH_TYPE === script.hash_type
+    );
   const data = [];
   if (scriptTemplate && scriptTemplate.SHORT_ID !== undefined) {
     data.push(1, scriptTemplate.SHORT_ID);
@@ -113,9 +122,9 @@ export const scriptToAddress = generateAddress;
 function generatePredefinedAddress(
   args: HexString,
   scriptType: string,
-  { config = undefined }: Options = {}
+  options: GenerateOptions = {}
 ): Address {
-  config = config || getConfig();
+  const config = options.config || getConfig();
   const template = config.SCRIPTS[scriptType]!;
   const script: Script = {
     code_hash: template.CODE_HASH,
@@ -123,23 +132,25 @@ function generatePredefinedAddress(
     args,
   };
 
-  return generateAddress(script, { config });
+  return generateAddress(script, options);
 }
 
 export function generateSecp256k1Blake160Address(
   args: HexString,
-  { config = undefined }: Options = {}
+  options: GenerateOptions = {}
 ): Address {
-  return generatePredefinedAddress(args, "SECP256K1_BLAKE160", { config });
+  return generatePredefinedAddress(args, "SECP256K1_BLAKE160", options);
 }
 
 export function generateSecp256k1Blake160MultisigAddress(
   args: HexString,
-  { config = undefined }: Options = {}
+  options: GenerateOptions = {}
 ): Address {
-  return generatePredefinedAddress(args, "SECP256K1_BLAKE160_MULTISIG", {
-    config,
-  });
+  return generatePredefinedAddress(
+    args,
+    "SECP256K1_BLAKE160_MULTISIG",
+    options
+  );
 }
 
 export function parseAddress(

--- a/packages/helpers/tests/generate_address.test.ts
+++ b/packages/helpers/tests/generate_address.test.ts
@@ -14,13 +14,19 @@ import {
 } from "./addresses";
 
 test("short address, mainnet", (t) => {
-  const address = generateAddress(shortAddressInfo.script, { config: LINA });
+  const address = generateAddress(shortAddressInfo.script, {
+    config: LINA,
+    __generateShortAddressWhenShortIDInConfig: true,
+  });
 
   t.is(address, shortAddressInfo.mainnetAddress);
 });
 
 test("short address, testnet", (t) => {
-  const address = generateAddress(shortAddressInfo.script, { config: AGGRON4 });
+  const address = generateAddress(shortAddressInfo.script, {
+    config: AGGRON4,
+    __generateShortAddressWhenShortIDInConfig: true,
+  });
 
   t.is(address, shortAddressInfo.testnetAddress);
 });
@@ -28,6 +34,7 @@ test("short address, testnet", (t) => {
 test("multisig short address, mainnet", (t) => {
   const address = generateAddress(multisigAddressInfo.script, {
     config: LINA,
+    __generateShortAddressWhenShortIDInConfig: true,
   });
 
   t.is(address, multisigAddressInfo.mainnetAddress);
@@ -36,6 +43,7 @@ test("multisig short address, mainnet", (t) => {
 test("multisig short address, testnet", (t) => {
   const address = generateAddress(multisigAddressInfo.script, {
     config: AGGRON4,
+    __generateShortAddressWhenShortIDInConfig: true,
   });
 
   t.is(address, multisigAddressInfo.testnetAddress);
@@ -58,7 +66,10 @@ test("full address, testnet", (t) => {
 });
 
 test("short address, mainnet, scriptToAddress", (t) => {
-  const address = scriptToAddress(shortAddressInfo.script, { config: LINA });
+  const address = scriptToAddress(shortAddressInfo.script, {
+    config: LINA,
+    __generateShortAddressWhenShortIDInConfig: true,
+  });
 
   t.is(address, shortAddressInfo.mainnetAddress);
 });
@@ -66,7 +77,7 @@ test("short address, mainnet, scriptToAddress", (t) => {
 test("generateSecp256k1Blake160Address, testnet", (t) => {
   const address = generateSecp256k1Blake160Address(
     shortAddressInfo.script.args,
-    { config: AGGRON4 }
+    { config: AGGRON4, __generateShortAddressWhenShortIDInConfig: true }
   );
 
   t.is(address, shortAddressInfo.testnetAddress);
@@ -75,7 +86,7 @@ test("generateSecp256k1Blake160Address, testnet", (t) => {
 test("generateSecp256k1Blake160Address, mainnet", (t) => {
   const address = generateSecp256k1Blake160Address(
     shortAddressInfo.script.args,
-    { config: LINA }
+    { config: LINA, __generateShortAddressWhenShortIDInConfig: true }
   );
 
   t.is(address, shortAddressInfo.mainnetAddress);
@@ -84,7 +95,7 @@ test("generateSecp256k1Blake160Address, mainnet", (t) => {
 test("generateSecp256k1Blake160MultisigAddress, testnet", (t) => {
   const address = generateSecp256k1Blake160MultisigAddress(
     multisigAddressInfo.script.args,
-    { config: AGGRON4 }
+    { config: AGGRON4, __generateShortAddressWhenShortIDInConfig: true }
   );
 
   t.is(address, multisigAddressInfo.testnetAddress);
@@ -93,7 +104,7 @@ test("generateSecp256k1Blake160MultisigAddress, testnet", (t) => {
 test("generateSecp256k1Blake160MultisigAddress, mainnet", (t) => {
   const address = generateSecp256k1Blake160MultisigAddress(
     multisigAddressInfo.script.args,
-    { config: LINA }
+    { config: LINA, __generateShortAddressWhenShortIDInConfig: true }
   );
 
   t.is(address, multisigAddressInfo.mainnetAddress);


### PR DESCRIPTION
## Breaking change

### `generateAddress`

```ts
// before
generateAddress(script) 

// after
generateAddress(script, { __generateShortAddressWhenShortIDInConfig: true } )
```

note: `parseAddress` We will be compatible with the current all format

## Background

Due to the upgrade of CKB2021, address format will also be upgrade, but this will cause the address to be difficult to understand,  after CKB2021 hard-fork, it will become `CKB2021 full address` /  `CKB2021 short address` / `CKB2019 full address` / `CKB2019 short address`. In order to avoid the complexity of address format, the CKB community will migrate to only support full format address.

