### PR TITLE
feat: supported Uint8Array for Reader in toolkit

### DIFF
--- a/packages/toolkit/index.d.ts
+++ b/packages/toolkit/index.d.ts
@@ -3,6 +3,8 @@ import JSBI from "jsbi";
 export class Reader {
   constructor(reader: string | ArrayBuffer | Reader);
   static fromRawString(s: string): Reader;
+  static isReader(x: unknown): x is Reader;
+  static from(x: string | ArrayBuffer | Reader | Uint8Array): Reader;
 
   length(): number;
   indexAt(i: number): number;

--- a/packages/toolkit/tests/reader.js
+++ b/packages/toolkit/tests/reader.js
@@ -1,0 +1,19 @@
+const test = require("ava");
+const { Reader } = require("../lib");
+
+test("reader functions", (t) => {
+  const ra = Reader.from("0x12345678");
+  const rb = Reader.from(Uint8Array.from([0x12, 0x34, 0x56, 0x78]));
+  const rc = Reader.from(Buffer.from("12345678", "hex"));
+  const rd = Reader.from(Uint8Array.from([0x12, 0x34, 0x56, 0x78]).buffer);
+
+  t.is(new DataView(ra.toArrayBuffer()).getUint32(0), 0x12345678);
+  t.is(new DataView(rb.toArrayBuffer()).getUint32(0), 0x12345678);
+  t.is(new DataView(rc.toArrayBuffer()).getUint32(0), 0x12345678);
+  t.is(new DataView(rd.toArrayBuffer()).getUint32(0), 0x12345678);
+
+  t.true(Reader.isReader(ra));
+  t.true(Reader.isReader(rb));
+  t.true(Reader.isReader(rc));
+  t.true(Reader.isReader(rd));
+});


### PR DESCRIPTION
Move content from this [pr](https://github.com/nervosnetwork/ckb-js-toolkit/pull/17)

```ts
// supported Uint8Array in Reader
// now we can create a Reader without new syntax
var reader = Reader.from(Uint8Array.from([0x12, 0x34, 0x56, 0x78]));

Reader.isReader(reader) // true
```