### PR TITLE
refactor!: remove deprecated CKB2021 API

### DIFF
--- a/docusaurus/website/src/components/AddressToScript.tsx
+++ b/docusaurus/website/src/components/AddressToScript.tsx
@@ -60,7 +60,6 @@ const LINA_SCRIPTS: config.ScriptConfigs = {
   },
 }
 const LINA_CONFIG = {
-  CKB2021: config.predefined.LINA.CKB2021,
   PREFIX: config.predefined.LINA.PREFIX,
   SCRIPTS: LINA_SCRIPTS
 }
@@ -97,7 +96,6 @@ const AGGRON4_SCRIPTS: config.ScriptConfigs = {
 }
 
 const AGGRON4_CONFIG = {
-  CKB2021: config.predefined.AGGRON4.CKB2021,
   PREFIX: config.predefined.AGGRON4.PREFIX,
   SCRIPTS: AGGRON4_SCRIPTS
 }

--- a/docusaurus/website/src/helpers/configHelper.ts
+++ b/docusaurus/website/src/helpers/configHelper.ts
@@ -15,8 +15,8 @@ export function toConfigWithoutShortId(
       DEP_TYPE: s.DEP_TYPE,
     };
   }
-  return config.CKB2019({
+  return {
     PREFIX: configWithShortId.PREFIX,
     SCRIPTS: newConfigScript,
-  });
+  };
 }

--- a/packages/config-manager/package.json
+++ b/packages/config-manager/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "fmt": "prettier --write \"{src,tests}/**/*.ts\" package.json",
     "lint": "eslint -c ../../.eslintrc.js \"{src,tests}/**/*.ts\"",
-    "test": "ava",
+    "test": "ava --timeout=2m",
     "build": "npm run build:types && npm run build:js",
     "build:types": "tsc --declaration --emitDeclarationOnly",
     "build:js": "babel --root-mode upward src --out-dir lib --extensions .ts -s",
@@ -45,5 +45,14 @@
     "@ckb-lumos/bi": "0.18.0-rc5",
     "@types/deep-freeze-strict": "^1.1.0",
     "deep-freeze-strict": "^1.1.1"
+  },
+  "ava": {
+    "extensions": [
+      "ts",
+      "js"
+    ],
+    "require": [
+      "ts-node/register"
+    ]
   }
 }

--- a/packages/config-manager/src/index.ts
+++ b/packages/config-manager/src/index.ts
@@ -1,10 +1,4 @@
 export * from "./types";
-export {
-  initializeConfig,
-  getConfig,
-  validateConfig,
-  CKB2019,
-  CKB2021,
-} from "./manager";
+export { initializeConfig, getConfig, validateConfig } from "./manager";
 export * as helpers from "./helpers";
 export { predefined, createConfig } from "./predefined";

--- a/packages/config-manager/src/manager.ts
+++ b/packages/config-manager/src/manager.ts
@@ -29,7 +29,7 @@ function assert(condition: unknown, debugPath = "variable"): asserts condition {
   if (!condition) throw new Error(`${debugPath} is not valid`);
 }
 
-export function validateConfig(config: Config) {
+export function validateConfig(config: Config): void {
   assert(
     typeof config.SCRIPTS === "object" && config.SCRIPTS != null,
     "config.SCRIPT"
@@ -97,6 +97,7 @@ function initializeConfigLegacy() {
   const configFile = env?.LUMOS_CONFIG_FILE;
   const configFilename = configFile || "config.json";
   try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const data = require("fs").readFileSync(configFilename);
     const loadedConfig = JSON.parse(data);
     validateConfig(loadedConfig);
@@ -116,29 +117,4 @@ export function initializeConfig(inputConfig?: Config): void {
     validateConfig(inputConfig);
     config = deepFreeze(inputConfig);
   }
-}
-/**
- * used to generate CKB address, but this will remove in the future, please migrate to {@link encodeToAddress}
- * @deprecated
- * @param config
- * @returns
- */
-export function CKB2019<Cfg extends Config>(config: Cfg): Cfg {
-  return {
-    ...config,
-    CKB2021: false,
-  };
-}
-
-/**
- * used to generate CKB address, but this will remove in the future, please migrate to {@link encodeToAddress}
- * @deprecated
- * @param config
- * @returns
- */
-export function CKB2021<Cfg extends Config>(config: Cfg): Cfg {
-  return {
-    ...config,
-    CKB2021: true,
-  };
 }

--- a/packages/config-manager/src/predefined.ts
+++ b/packages/config-manager/src/predefined.ts
@@ -8,7 +8,6 @@ export type ScriptRecord = Record<string, ScriptConfig>;
  * @param configShape
  */
 export function createConfig<S extends ScriptRecord>(configShape: {
-  CKB2021?: boolean;
   PREFIX: string;
   SCRIPTS: S;
 }): typeof configShape {

--- a/packages/config-manager/src/types.ts
+++ b/packages/config-manager/src/types.ts
@@ -21,11 +21,6 @@ export interface ScriptConfigs {
  * own address prefix, and its own set of deployed scripts.
  */
 export interface Config {
-  /**
-   * @deprecated
-   * defaults to true, used to generate CKB address, but this will be removed in the future, please migrate to {@link encodeToAddress}
-   */
-  CKB2021?: boolean;
   PREFIX: string;
   SCRIPTS: ScriptConfigs;
 }

--- a/packages/config-manager/tests/manager.test.ts
+++ b/packages/config-manager/tests/manager.test.ts
@@ -1,0 +1,18 @@
+import { initializeConfig, predefined } from "../src";
+import test from "ava";
+import fs from "fs";
+import path from "path";
+
+test("[deprecated] initialize config by file", (t) => {
+  t.throws(() => initializeConfig());
+
+  const configPath = path.join(__dirname, "config.json");
+  process.env.LUMOS_CONFIG_FILE = configPath;
+  fs.writeFileSync(
+    configPath,
+    Buffer.from(JSON.stringify(predefined.LINA), "utf8")
+  );
+  initializeConfig();
+  fs.unlinkSync(configPath);
+  t.pass();
+});

--- a/packages/config-manager/tests/predefined.test.ts
+++ b/packages/config-manager/tests/predefined.test.ts
@@ -1,0 +1,7 @@
+import test from "ava";
+import { createConfig } from "../src";
+
+test("createConfig should be frozen", (t) => {
+  const config = createConfig({ PREFIX: "ckt", SCRIPTS: {} });
+  t.true(Object.isFrozen(config));
+});

--- a/packages/config-manager/tests/validator.js
+++ b/packages/config-manager/tests/validator.js
@@ -34,4 +34,8 @@ test("invalidate config", (t) => {
       },
     });
   });
+
+  t.throws(() => {
+    validateConfig(null);
+  });
 });

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -115,21 +115,6 @@ export function generateAddress(
   if (scriptTemplate && scriptTemplate.SHORT_ID !== undefined) {
     data.push(1, scriptTemplate.SHORT_ID);
     data.push(...hexToByteArray(script.args));
-  } else if (config.CKB2021) {
-    const hash_type = (() => {
-      if (script.hash_type === "data") return 0;
-      if (script.hash_type === "type") return 1;
-      if (script.hash_type === "data1") return 2;
-
-      throw new Error(`unknown hash_type ${script.hash_type}`);
-    })();
-
-    data.push(0x00);
-    data.push(...hexToByteArray(script.code_hash));
-    data.push(hash_type);
-    data.push(...hexToByteArray(script.args));
-
-    return bech32m.encode(config.PREFIX, bech32m.toWords(data), BECH32_LIMIT);
   } else {
     data.push(script.hash_type === "type" ? 4 : 2);
     data.push(...hexToByteArray(script.code_hash));

--- a/packages/helpers/tests/generate_address.test.ts
+++ b/packages/helpers/tests/generate_address.test.ts
@@ -5,10 +5,10 @@ import {
   generateSecp256k1Blake160MultisigAddress,
   scriptToAddress,
 } from "../src";
-import { predefined, CKB2019 } from "@ckb-lumos/config-manager";
+import { predefined } from "@ckb-lumos/config-manager";
 
-const LINA = CKB2019(predefined.LINA);
-const AGGRON4 = CKB2019(predefined.AGGRON4);
+const LINA = predefined.LINA;
+const AGGRON4 = predefined.AGGRON4;
 
 import {
   shortAddressInfo,

--- a/packages/helpers/tests/generate_address_ckb2021.test.ts
+++ b/packages/helpers/tests/generate_address_ckb2021.test.ts
@@ -1,10 +1,10 @@
 import test from "ava";
-import { encodeToAddress, generateAddress } from "../src";
-import { CKB2021, Config, predefined } from "@ckb-lumos/config-manager";
+import { encodeToAddress } from "../src";
+import { Config, predefined } from "@ckb-lumos/config-manager";
 import { HashType, Script } from "@ckb-lumos/base";
 
-const LINA = CKB2021(predefined.LINA);
-const AGGRON4 = CKB2021(predefined.AGGRON4);
+const LINA = predefined.LINA;
+const AGGRON4 = predefined.AGGRON4;
 
 type NetworkType = keyof typeof predefined;
 
@@ -29,139 +29,15 @@ function ScriptFrom(
 
 function ConfigFrom(
   networkType: NetworkType,
-  options: { excludeShortId?: boolean; CKB2021?: boolean } = {}
+  options: { excludeShortId?: boolean } = {}
 ): Config {
   const { excludeShortId = false } = options;
-  const config = options.CKB2021
-    ? CKB2021(predefined[networkType])
-    : predefined[networkType];
+  const config = predefined[networkType];
   return {
     ...config,
     SCRIPTS: excludeShortId ? {} : config.SCRIPTS,
   };
 }
-
-test("default short address (code_hash_index = 0x00)", (t) => {
-  const script = ScriptFrom(
-    "SECP256K1_BLAKE160",
-    "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64"
-  );
-
-  t.is(
-    generateAddress(script.LINA, { config: ConfigFrom("LINA") }),
-    "ckb1qyqt8xaupvm8837nv3gtc9x0ekkj64vud3jqfwyw5v"
-  );
-
-  t.is(
-    generateAddress(script.AGGRON4, { config: ConfigFrom("AGGRON4") }),
-    "ckt1qyqt8xaupvm8837nv3gtc9x0ekkj64vud3jq5t63cs"
-  );
-});
-
-test("multisign short address (code_hash_index = 0x01)", (t) => {
-  const script = ScriptFrom(
-    "SECP256K1_BLAKE160_MULTISIG",
-    "0x4fb2be2e5d0c1a3b8694f832350a33c1685d477a"
-  );
-
-  t.is(
-    generateAddress(script.LINA, { config: ConfigFrom("LINA") }),
-    "ckb1qyq5lv479ewscx3ms620sv34pgeuz6zagaaqklhtgg"
-  );
-
-  t.is(
-    generateAddress(script.AGGRON4, { config: ConfigFrom("AGGRON4") }),
-    "ckt1qyq5lv479ewscx3ms620sv34pgeuz6zagaaqt6f5y5"
-  );
-});
-
-test("acp short address (code_hash_index = 0x02)", (t) => {
-  const script = ScriptFrom(
-    "ANYONE_CAN_PAY",
-    "0xbd07d9f32bce34d27152a6a0391d324f79aab854"
-  );
-
-  t.is(
-    generateAddress(script.LINA, { config: ConfigFrom("LINA") }),
-    "ckb1qypt6p7e7v4uudxjw9f2dgper5ey77d2hp2qxz4u4u"
-  );
-
-  t.is(
-    generateAddress(script.AGGRON4, { config: ConfigFrom("AGGRON4") }),
-    "ckt1qypt6p7e7v4uudxjw9f2dgper5ey77d2hp2qm8treq"
-  );
-});
-
-test("full address test (hash_type = 0x00)", (t) => {
-  const script: Script = {
-    code_hash:
-      "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-    hash_type: "data",
-    args: "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64",
-  };
-
-  t.is(
-    generateAddress(script, {
-      config: CKB2021(
-        ConfigFrom("LINA", { excludeShortId: true, CKB2021: true })
-      ),
-    }),
-    "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq9nnw7qkdnnclfkg59uzn8umtfd2kwxceqvguktl"
-  );
-
-  t.is(
-    generateAddress(script, {
-      config: ConfigFrom("AGGRON4", { excludeShortId: true, CKB2021: true }),
-    }),
-    "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq9nnw7qkdnnclfkg59uzn8umtfd2kwxceqz6hep8"
-  );
-});
-
-test("full address test (hash_type = 0x01)", (t) => {
-  const script: Script = {
-    code_hash:
-      "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-    hash_type: "type",
-    args: "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64",
-  };
-
-  t.is(
-    generateAddress(script, {
-      config: ConfigFrom("LINA", { excludeShortId: true, CKB2021: true }),
-    }),
-    "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqdnnw7qkdnnclfkg59uzn8umtfd2kwxceqxwquc4"
-  );
-
-  t.is(
-    generateAddress(script, {
-      config: ConfigFrom("AGGRON4", { excludeShortId: true, CKB2021: true }),
-    }),
-    "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqdnnw7qkdnnclfkg59uzn8umtfd2kwxceqgutnjd"
-  );
-});
-
-test("full address test (hash_type = 0x02)", (t) => {
-  const script: Script = {
-    code_hash:
-      "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-    hash_type: "data1",
-    args: "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64",
-  };
-
-  t.is(
-    generateAddress(script, {
-      config: ConfigFrom("LINA", { excludeShortId: true, CKB2021: true }),
-    }),
-    "ckb1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq4nnw7qkdnnclfkg59uzn8umtfd2kwxceqcydzyt"
-  );
-
-  t.is(
-    generateAddress(script, {
-      config: ConfigFrom("AGGRON4", { excludeShortId: true, CKB2021: true }),
-    }),
-    "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq4nnw7qkdnnclfkg59uzn8umtfd2kwxceqkkxdwn"
-  );
-});
 
 test("[encodeToAddress] full address test (hash_type = 0x02)", (t) => {
   const script: Script = {


### PR DESCRIPTION
This PR removes the deprecated `CKB2021` config item in Config, the related CKB2019/CKB2021 API will be remove too.

The CKB2021 address was finally standardized to use [only the bech32m encoding](https://github.com/nervosnetwork/rfcs/blob/e68de36ba4275648339b88b0844affb3b83652fa/rfcs/0021-ckb-address-format/0021-ckb-address-format.md) and there is no longer [a mix of bech32m and bech32](https://github.com/nervosnetwork/rfcs/blob/a7f8def7bf657a387f383aa55369a03e78ef9134/rfcs/0021-ckb-address-format/0021-ckb-address-format.md). For the CKB2019 address, we can continue to use `generateAddress` for address generation, but we recommend that your application use `encodeToAddress` to use the CKB2021 address format


```diff
import { helpers, config } from '@ckb-lumos/lumos'

- helpers.generateAddress(script) // CKB2019 address
+ helpers.encodeToAddress(script) // CKB2021 address


- initializeConfig(config.CKB2019(config.predefined.AGGRON))
- initializeConfig(config.CKB2021(config.predefined.AGGRON))
+ initializeConfig(config.predefined.AGGRON)
```