### PR TITLE
perf(ckb-indexer): filter out unnecessary indexer data requests

### DIFF
--- a/packages/ckb-indexer/src/collector.ts
+++ b/packages/ckb-indexer/src/collector.ts
@@ -43,11 +43,11 @@ export class CKBCellCollector implements BaseCellCollector {
       bufferSize: undefined,
     };
     this.queries = { ...defaultQuery, ...this.queries };
-    this.validateParams(this.queries);
-    this.convertParams();
+    this.validateQueryOption(this.queries);
+    this.convertQueryOptionToSearchKey();
   }
 
-  public validateParams(queries: CKBIndexerQueryOptions): void {
+  public validateQueryOption(queries: CKBIndexerQueryOptions): void {
     if (!queries.lock && (!queries.type || queries.type === "empty")) {
       throw new Error("Either lock or type script must be provided!");
     }
@@ -124,7 +124,7 @@ export class CKBCellCollector implements BaseCellCollector {
     }
   }
 
-  public convertParams(): void {
+  public convertQueryOptionToSearchKey(): void {
     // unWrap `ScriptWrapper` into `Script`.
     if (this.queries.lock) {
       if (instanceOfScriptWrapper(this.queries.lock)) {

--- a/packages/ckb-indexer/tests/cell_collector.unit.test.ts
+++ b/packages/ckb-indexer/tests/cell_collector.unit.test.ts
@@ -13,52 +13,43 @@ const lockScript: Script = {
   args: "0xbde8b19b4505dd1d1310223edecea20adc4e240e",
 };
 
-test.serial(
-  "convertParams# should set outputDataLenRange according to data",
-  (t) => {
-    const query = {
-      lock: lockScript,
-      data: "0x",
-    };
-    const cellCollect = new CellCollector(indexer, query);
-    cellCollect.convertQueryOptionToSearchKey();
-    t.deepEqual(cellCollect.queries.outputDataLenRange, ["0x0", "0x1"]);
-  }
-);
+test("convertParams# should set outputDataLenRange according to data", (t) => {
+  const query = {
+    lock: lockScript,
+    data: "0x",
+  };
+  const cellCollect = new CellCollector(indexer, query);
+  cellCollect.convertQueryOptionToSearchKey();
+  t.deepEqual(cellCollect.queries.outputDataLenRange, ["0x0", "0x1"]);
+});
 
-test.serial(
-  "convertParams# should not set outputDataRange if data is not defined",
-  (t) => {
-    const query = {
-      lock: lockScript,
-    };
-    const cellCollect = new CellCollector(indexer, query);
-    cellCollect.convertQueryOptionToSearchKey();
-    t.deepEqual(cellCollect.queries.outputDataLenRange, undefined);
-  }
-);
+test("convertParams# should not set outputDataRange if data is not defined", (t) => {
+  const query = {
+    lock: lockScript,
+  };
+  const cellCollect = new CellCollector(indexer, query);
+  cellCollect.convertQueryOptionToSearchKey();
+  t.deepEqual(cellCollect.queries.outputDataLenRange, undefined);
+});
 
-test.serial(
-  "convertParams# should match outputDataRange if data and outputData both defined",
-  (t) => {
-    const outputDataLenRange: HexadecimalRange = ["0x0", "0x2"];
-    const query = {
-      lock: lockScript,
-      data: "0x",
-      outputDataLenRange,
-    };
-    const cellCollect = new CellCollector(indexer, query);
-    cellCollect.convertQueryOptionToSearchKey();
-    t.deepEqual(cellCollect.queries.outputDataLenRange, ["0x0", "0x2"]);
+test("convertParams# should match outputDataRange if data and outputData both defined", (t) => {
+  const outputDataLenRange: HexadecimalRange = ["0x0", "0x2"];
+  const query = {
+    lock: lockScript,
+    data: "0x",
+    outputDataLenRange,
+  };
+  const cellCollect = new CellCollector(indexer, query);
+  cellCollect.convertQueryOptionToSearchKey();
+  t.deepEqual(cellCollect.queries.outputDataLenRange, ["0x0", "0x2"]);
 
-    const notMatchQuery = {
-      lock: lockScript,
-      data: "0x664455",
-      outputDataLenRange,
-    };
-    const error = t.throws(() => {
-      new CellCollector(indexer, notMatchQuery);
-    });
-    t.is(error.message, "data length not match outputDataLenRange");
-  }
-);
+  const notMatchQuery = {
+    lock: lockScript,
+    data: "0x664455",
+    outputDataLenRange,
+  };
+  const error = t.throws(() => {
+    new CellCollector(indexer, notMatchQuery);
+  });
+  t.is(error.message, "data length not match outputDataLenRange");
+});

--- a/packages/ckb-indexer/tests/cell_collector.unit.test.ts
+++ b/packages/ckb-indexer/tests/cell_collector.unit.test.ts
@@ -20,7 +20,7 @@ test.serial(
       data: "0x",
     };
     const cellCollect = new CellCollector(indexer, query);
-    cellCollect.convertParams();
+    cellCollect.convertQueryOptionToSearchKey();
     t.deepEqual(cellCollect.queries.outputDataLenRange, ["0x0", "0x1"]);
   }
 );
@@ -38,7 +38,7 @@ test.serial(
       lock: lockScript,
     };
     const cellCollect = new CellCollector(indexer, query);
-    cellCollect.convertParams();
+    cellCollect.convertQueryOptionToSearchKey();
     t.deepEqual(cellCollect.queries.outputDataLenRange, undefined);
   }
 );
@@ -59,7 +59,7 @@ test.serial.only(
       outputDataLenRange,
     };
     const cellCollect = new CellCollector(indexer, query);
-    cellCollect.convertParams();
+    cellCollect.convertQueryOptionToSearchKey();
     t.deepEqual(cellCollect.queries.outputDataLenRange, ["0x0", "0x2"]);
 
     const notMatchQuery = {

--- a/packages/ckb-indexer/tests/cell_collector.unit.test.ts
+++ b/packages/ckb-indexer/tests/cell_collector.unit.test.ts
@@ -1,11 +1,22 @@
 import test from "ava";
 import { Indexer, CellCollector } from "../src";
-import { HexadecimalRange, Script } from "@ckb-lumos/base";
+import { HexadecimalRange, Script, utils } from "@ckb-lumos/base";
+import sinon, { SinonSpy } from "sinon";
+import { validators } from "@ckb-lumos/toolkit";
 
 const nodeUri = "http://127.0.0.1:8118/rpc";
 const indexUri = "http://127.0.0.1:8120";
 const indexer = new Indexer(indexUri, nodeUri);
 
+let validateScriptSpy: SinonSpy;
+let utilsSpy: SinonSpy;
+test.before(() => {
+  validateScriptSpy = sinon.spy(validators, "ValidateScript");
+  utilsSpy = sinon.spy(utils, "assertHexadecimal");
+});
+test.afterEach(() => {
+  validateScriptSpy.resetHistory();
+});
 const lockScript: Script = {
   code_hash:
     "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
@@ -52,4 +63,74 @@ test("convertParams# should match outputDataRange if data and outputData both de
     new CellCollector(indexer, notMatchQuery);
   });
   t.is(error.message, "data length not match outputDataLenRange");
+});
+
+test("validateQueryOption#should throw error if lock and type not provided", (t) => {
+  t.throws(
+    () => {
+      new CellCollector(indexer, {});
+    },
+    undefined,
+    "throw error if lock and query both not provided"
+  );
+
+  t.throws(
+    () => {
+      new CellCollector(indexer, {
+        type: "empty",
+      });
+    },
+    undefined,
+    "throw error if lock is not provided and type is empty"
+  );
+});
+
+test("validateQueryOption#validate lock if lock is script", (t) => {
+  const query = {
+    lock: lockScript,
+  };
+  new CellCollector(indexer, query);
+  t.is(validateScriptSpy.calledWith(query.lock), true);
+});
+
+test("validateQueryOption#validate lock.script if lock is ScriptWrapper", (t) => {
+  const query = {
+    lock: { script: lockScript, argsLen: 20 },
+  };
+  new CellCollector(indexer, query);
+  t.is(validateScriptSpy.calledWith(query.lock.script), true);
+});
+
+test("validateQueryOption#validate type if type is script", (t) => {
+  const query = {
+    type: lockScript,
+  };
+  new CellCollector(indexer, query);
+  t.is(validateScriptSpy.calledWith(query.type), true);
+});
+
+test("validateQueryOption#validate type.script if type is ScriptWrapper", (t) => {
+  const query = {
+    type: { script: lockScript, argsLen: 20 },
+  };
+  new CellCollector(indexer, query);
+  t.is(validateScriptSpy.calledWith(query.type.script), true);
+});
+
+test("validateQueryOption#validate fromBlock", (t) => {
+  const query = {
+    lock: lockScript,
+    fromBlock: "0x1",
+  };
+  new CellCollector(indexer, query);
+  t.is(utilsSpy.calledWith("fromBlock", "0x1"), true);
+});
+
+test("validateQueryOption#validate toBlock", (t) => {
+  const query = {
+    lock: lockScript,
+    toBlock: "0x3",
+  };
+  new CellCollector(indexer, query);
+  t.is(utilsSpy.calledWith("toBlock", "0x3"), true);
 });

--- a/packages/ckb-indexer/tests/cell_collector.unit.test.ts
+++ b/packages/ckb-indexer/tests/cell_collector.unit.test.ts
@@ -134,3 +134,25 @@ test("validateQueryOption#validate toBlock", (t) => {
   new CellCollector(indexer, query);
   t.is(utilsSpy.calledWith("toBlock", "0x3"), true);
 });
+
+test("validateQueryOption#validate outputCapacityRange", (t) => {
+  const outputCapacityRange: HexadecimalRange = ["0x100", "0x200"];
+  const query = {
+    lock: lockScript,
+    outputCapacityRange,
+  };
+  new CellCollector(indexer, query);
+  t.is(utilsSpy.calledWith("outputCapacityRange[0]", "0x100"), true);
+  t.is(utilsSpy.calledWith("outputCapacityRange[1]", "0x200"), true);
+});
+
+test("validateQueryOption#validate outputDataLenRange", (t) => {
+  const outputDataLenRange: HexadecimalRange = ["0x100", "0x200"];
+  const query = {
+    lock: lockScript,
+    outputDataLenRange,
+  };
+  new CellCollector(indexer, query);
+  t.is(utilsSpy.calledWith("outputDataLenRange[0]", "0x100"), true);
+  t.is(utilsSpy.calledWith("outputDataLenRange[1]", "0x200"), true);
+});

--- a/packages/ckb-indexer/tests/cell_collector.unit.test.ts
+++ b/packages/ckb-indexer/tests/cell_collector.unit.test.ts
@@ -52,7 +52,7 @@ test.serial.only(
       hash_type: "type",
       args: "0xbde8b19b4505dd1d1310223edecea20adc4e240e",
     };
-    const outputDataLenRange: HexadecimalRange = ["0x0", "0x5"];
+    const outputDataLenRange: HexadecimalRange = ["0x0", "0x2"];
     const query = {
       lock: lockScript,
       data: "0x",
@@ -60,6 +60,16 @@ test.serial.only(
     };
     const cellCollect = new CellCollector(indexer, query);
     cellCollect.convertParams();
-    t.deepEqual(cellCollect.queries.outputDataLenRange, ["0x0", "0x5"]);
+    t.deepEqual(cellCollect.queries.outputDataLenRange, ["0x0", "0x2"]);
+
+    const notMatchQuery = {
+      lock: lockScript,
+      data: "0x664455",
+      outputDataLenRange,
+    };
+    const error = t.throws(() => {
+      new CellCollector(indexer, notMatchQuery);
+    });
+    t.is(error.message, "data length not match outputDataLenRange");
   }
 );

--- a/packages/ckb-indexer/tests/cell_collector.unit.test.ts
+++ b/packages/ckb-indexer/tests/cell_collector.unit.test.ts
@@ -1,0 +1,65 @@
+import test from "ava";
+import { Indexer, CellCollector } from "../src";
+import { HexadecimalRange, Script } from "@ckb-lumos/base";
+
+const nodeUri = "http://127.0.0.1:8118/rpc";
+const indexUri = "http://127.0.0.1:8120";
+const indexer = new Indexer(indexUri, nodeUri);
+
+test.serial(
+  "convertParams# should set outputDataLenRange according to data",
+  (t) => {
+    const lockScript: Script = {
+      code_hash:
+        "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+      hash_type: "type",
+      args: "0xbde8b19b4505dd1d1310223edecea20adc4e240e",
+    };
+    const query = {
+      lock: lockScript,
+      data: "0x",
+    };
+    const cellCollect = new CellCollector(indexer, query);
+    cellCollect.convertParams();
+    t.deepEqual(cellCollect.queries.outputDataLenRange, ["0x0", "0x1"]);
+  }
+);
+
+test.serial(
+  "convertParams# should not set outputDataRange if data is not defined",
+  (t) => {
+    const lockScript: Script = {
+      code_hash:
+        "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+      hash_type: "type",
+      args: "0xbde8b19b4505dd1d1310223edecea20adc4e240e",
+    };
+    const query = {
+      lock: lockScript,
+    };
+    const cellCollect = new CellCollector(indexer, query);
+    cellCollect.convertParams();
+    t.deepEqual(cellCollect.queries.outputDataLenRange, undefined);
+  }
+);
+
+test.serial.only(
+  "convertParams# should match outputDataRange if data and outputData both defined",
+  (t) => {
+    const lockScript: Script = {
+      code_hash:
+        "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+      hash_type: "type",
+      args: "0xbde8b19b4505dd1d1310223edecea20adc4e240e",
+    };
+    const outputDataLenRange: HexadecimalRange = ["0x0", "0x5"];
+    const query = {
+      lock: lockScript,
+      data: "0x",
+      outputDataLenRange,
+    };
+    const cellCollect = new CellCollector(indexer, query);
+    cellCollect.convertParams();
+    t.deepEqual(cellCollect.queries.outputDataLenRange, ["0x0", "0x5"]);
+  }
+);

--- a/packages/ckb-indexer/tests/cell_collector.unit.test.ts
+++ b/packages/ckb-indexer/tests/cell_collector.unit.test.ts
@@ -6,15 +6,16 @@ const nodeUri = "http://127.0.0.1:8118/rpc";
 const indexUri = "http://127.0.0.1:8120";
 const indexer = new Indexer(indexUri, nodeUri);
 
+const lockScript: Script = {
+  code_hash:
+    "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+  hash_type: "type",
+  args: "0xbde8b19b4505dd1d1310223edecea20adc4e240e",
+};
+
 test.serial(
   "convertParams# should set outputDataLenRange according to data",
   (t) => {
-    const lockScript: Script = {
-      code_hash:
-        "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-      hash_type: "type",
-      args: "0xbde8b19b4505dd1d1310223edecea20adc4e240e",
-    };
     const query = {
       lock: lockScript,
       data: "0x",
@@ -28,12 +29,6 @@ test.serial(
 test.serial(
   "convertParams# should not set outputDataRange if data is not defined",
   (t) => {
-    const lockScript: Script = {
-      code_hash:
-        "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-      hash_type: "type",
-      args: "0xbde8b19b4505dd1d1310223edecea20adc4e240e",
-    };
     const query = {
       lock: lockScript,
     };
@@ -43,15 +38,9 @@ test.serial(
   }
 );
 
-test.serial.only(
+test.serial(
   "convertParams# should match outputDataRange if data and outputData both defined",
   (t) => {
-    const lockScript: Script = {
-      code_hash:
-        "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-      hash_type: "type",
-      args: "0xbde8b19b4505dd1d1310223edecea20adc4e240e",
-    };
     const outputDataLenRange: HexadecimalRange = ["0x0", "0x2"];
     const query = {
       lock: lockScript,


### PR DESCRIPTION
`@ckb-lumos/ckb-indexer` based on `ckb-indexer`,and ckb-indexer `outputDataLenRange` filed support  prefix match data len.
when you do `get_cells` action with data filed specify. this PR can you deduce  `outputDataLenRange` . so we can get_cell from indexer rpc more efficient.

for example. if you set your queries as below.
```js
{
    lock: {
        code_hash:
          "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
        hash_type: "type",
        args: "0xbde8b19b4505dd1d1310223edecea20adc4e240e",
      },
    data: "0x",
  }
```
lumos helps you to covert your queries  as below in background.

```js
{
    lock: {
        code_hash:
          "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
        hash_type: "type",
        args: "0xbde8b19b4505dd1d1310223edecea20adc4e240e",
      },
    data: "0x",
   outputDataLenRange: ["0x0" , "0x1"]
  }
```
