### PR TITLE
feat(codec): molecule unpack works with BytesLike

### DIFF
--- a/packages/codec/src/base.ts
+++ b/packages/codec/src/base.ts
@@ -49,7 +49,7 @@ export type UnpackParam<T extends AnyCodec> = T extends Codec<
   ? Unpackable
   : never;
 
-export type BytesCodec<Unpacked = any, Packable = Unpacked> = Codec<
+export type Uint8ArrayCodec<Unpacked = any, Packable = Unpacked> = Codec<
   Uint8Array,
   Unpacked,
   Packable
@@ -64,12 +64,17 @@ export type BytesLikeCodec<Unpacked = any, Packable = Unpacked> = Codec<
   BytesLike
 >;
 
+export type BytesCodec<Unpacked = any, Packable = Unpacked> = BytesLikeCodec<
+  Unpacked,
+  Packable
+>;
+
 /**
  * This function helps to create a codec that can
  * @param codec
  */
 export function createBytesCodec<Unpacked, Packable = Unpacked>(
-  codec: BytesCodec<Unpacked, Packable>
+  codec: Uint8ArrayCodec<Unpacked, Packable>
 ): BytesLikeCodec<Unpacked, Packable> {
   return {
     pack: (unpacked) => codec.pack(unpacked),
@@ -100,7 +105,7 @@ export function isFixedCodec<T>(
 }
 
 export function createFixedBytesCodec<Unpacked, Packable = Unpacked>(
-  codec: BytesCodec<Unpacked, Packable> & { byteLength: number }
+  codec: Uint8ArrayCodec<Unpacked, Packable> & { byteLength: number }
 ): FixedBytesLikeCodec<Unpacked, Packable> {
   const byteLength = codec.byteLength;
   return {

--- a/packages/codec/src/base.ts
+++ b/packages/codec/src/base.ts
@@ -57,16 +57,11 @@ export type Uint8ArrayCodec<Unpacked = any, Packable = Unpacked> = Codec<
 
 export type BytesLike = ArrayLike<number> | ArrayBuffer | string;
 
-export type BytesLikeCodec<Unpacked = any, Packable = Unpacked> = Codec<
+export type BytesCodec<Unpacked = any, Packable = Unpacked> = Codec<
   Uint8Array,
   Unpacked,
   Packable,
   BytesLike
->;
-
-export type BytesCodec<Unpacked = any, Packable = Unpacked> = BytesLikeCodec<
-  Unpacked,
-  Packable
 >;
 
 /**
@@ -75,7 +70,7 @@ export type BytesCodec<Unpacked = any, Packable = Unpacked> = BytesLikeCodec<
  */
 export function createBytesCodec<Unpacked, Packable = Unpacked>(
   codec: Uint8ArrayCodec<Unpacked, Packable>
-): BytesLikeCodec<Unpacked, Packable> {
+): BytesCodec<Unpacked, Packable> {
   return {
     pack: (unpacked) => codec.pack(unpacked),
     unpack: (bytesLike) => codec.unpack(bytify(bytesLike)),
@@ -93,11 +88,6 @@ export type FixedBytesCodec<Unpacked = any, Packable = Unpacked> = BytesCodec<
 > &
   Fixed;
 
-export type FixedBytesLikeCodec<
-  Unpacked = any,
-  Packable = Unpacked
-> = BytesLikeCodec<Unpacked, Packable> & Fixed;
-
 export function isFixedCodec<T>(
   codec: BytesCodec<T>
 ): codec is FixedBytesCodec<T> {
@@ -106,7 +96,7 @@ export function isFixedCodec<T>(
 
 export function createFixedBytesCodec<Unpacked, Packable = Unpacked>(
   codec: Uint8ArrayCodec<Unpacked, Packable> & { byteLength: number }
-): FixedBytesLikeCodec<Unpacked, Packable> {
+): FixedBytesCodec<Unpacked, Packable> {
   const byteLength = codec.byteLength;
   return {
     __isFixedCodec__: true,

--- a/packages/codec/src/blockchain.ts
+++ b/packages/codec/src/blockchain.ts
@@ -1,9 +1,11 @@
 import {
   AnyCodec,
   BytesCodec,
+  BytesLike,
   createBytesCodec,
   createFixedBytesCodec,
   FixedBytesCodec,
+  PackParam,
   UnpackResult,
 } from "./base";
 import { bytify, hexify } from "./bytes";
@@ -47,11 +49,18 @@ export function WitnessArgsOf<
   lock: LockCodec;
   input_type: InputTypeCodec;
   output_type: OutputTypeCodec;
-}): BytesCodec<{
-  lock?: UnpackResult<LockCodec>;
-  input_type?: UnpackResult<InputTypeCodec>;
-  output_type?: UnpackResult<OutputTypeCodec>;
-}> {
+}): BytesCodec<
+  {
+    lock?: UnpackResult<LockCodec>;
+    input_type?: UnpackResult<InputTypeCodec>;
+    output_type?: UnpackResult<OutputTypeCodec>;
+  },
+  {
+    lock?: PackParam<LockCodec>;
+    input_type?: PackParam<InputTypeCodec>;
+    output_type?: PackParam<OutputTypeCodec>;
+  }
+> {
   return table(
     {
       lock: option(byteVecOf(payload.lock)),
@@ -62,7 +71,10 @@ export function WitnessArgsOf<
   );
 }
 
-const HexifyCodec = createBytesCodec<string>({ pack: bytify, unpack: hexify });
+const HexifyCodec = createBytesCodec<string, BytesLike>({
+  pack: bytify,
+  unpack: hexify,
+});
 
 /**
  *

--- a/packages/codec/src/molecule/helper.ts
+++ b/packages/codec/src/molecule/helper.ts
@@ -1,6 +1,11 @@
 import { assertBufferLength, assertMinBufferLength } from "../utils";
 import { concat } from "../bytes";
-import { BytesCodec, createFixedBytesCodec, FixedBytesCodec } from "../base";
+import {
+  BytesCodec,
+  createBytesCodec,
+  createFixedBytesCodec,
+  FixedBytesCodec,
+} from "../base";
 import { Uint32LE } from "../number";
 
 /**
@@ -30,8 +35,8 @@ export function byteOf<T>(codec: BytesCodec<T>): FixedBytesCodec<T> {
  * a helper function to create custom codec of `vector Bytes <byte>`
  * @param codec
  */
-export function byteVecOf<T>(codec: BytesCodec<T>): BytesCodec<T> {
-  return {
+export const byteVecOf = <T>(codec: BytesCodec<T>): BytesCodec<T> => {
+  return createBytesCodec({
     pack(unpacked) {
       const payload = codec.pack(unpacked);
       const header = Uint32LE.pack(payload.byteLength);
@@ -44,5 +49,5 @@ export function byteVecOf<T>(codec: BytesCodec<T>): BytesCodec<T> {
       assertBufferLength(packed.slice(4), header);
       return codec.unpack(packed.slice(4));
     },
-  };
-}
+  });
+};

--- a/packages/codec/src/number/uint.ts
+++ b/packages/codec/src/number/uint.ts
@@ -1,5 +1,5 @@
 import { BI, BIish } from "@ckb-lumos/bi";
-import { createFixedBytesCodec, FixedBytesLikeCodec } from "../base";
+import { createFixedBytesCodec, FixedBytesCodec } from "../base";
 
 function assertNumberRange(value: BIish, min: BIish, max: BIish): void {
   value = BI.from(value);
@@ -14,7 +14,7 @@ function assertNumberRange(value: BIish, min: BIish, max: BIish): void {
 function createUintNumberCodec(
   byteLength: number,
   littleEndian = false
-): FixedBytesLikeCodec<number, BIish> {
+): FixedBytesCodec<number, BIish> {
   const codec = createUintBICodec(byteLength, littleEndian);
   return {
     __isFixedCodec__: true,

--- a/packages/codec/tests/blockchain.test.ts
+++ b/packages/codec/tests/blockchain.test.ts
@@ -8,7 +8,7 @@ const SECP256K1_SIGNATURE_LENGTH = 65;
 
 test("secp256k1 witness args", (t) => {
   const unsigned = WitnessArgs.pack({
-    lock: hexify(Buffer.alloc(SECP256K1_SIGNATURE_LENGTH)),
+    lock: Buffer.alloc(SECP256K1_SIGNATURE_LENGTH),
   });
 
   t.deepEqual(
@@ -16,6 +16,17 @@ test("secp256k1 witness args", (t) => {
     bytify(
       "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
     )
+  );
+
+  t.deepEqual(
+    WitnessArgs.unpack(
+      "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    ),
+    {
+      lock: hexify(Buffer.alloc(SECP256K1_SIGNATURE_LENGTH)),
+      input_type: undefined,
+      output_type: undefined,
+    }
   );
 
   const signature = bytify(randomBytes(SECP256K1_SIGNATURE_LENGTH));


### PR DESCRIPTION
## Motivation

When we pack or unpack, the molecule codec only allows us to pass in qualified types like `HexString` or `Uint8Array` to represent binary data.
The codec would be more convenient if we could pass `BytesLike` directly

## How

```ts
const RGB = struct({ r: Uint8, g: Uint8, b: Uint8 }, ["r", "g", "b"]);

// the array of number is OK
console.log(RGB.unpack([255, 255, 255]));

// also the HexString is OK
console.log(RGB.unpack("0xffffff"));
```

```ts
// with 65 bytes lock placehoder
WitnessArgs.pack({
  lock: new Uint8Array(65)
})
```