### PR TITLE
perf(codec): avoid re-construct when concat bytes

### DIFF
--- a/packages/codec/src/bytes.ts
+++ b/packages/codec/src/bytes.ts
@@ -50,9 +50,18 @@ export function hexify(buf: BytesLike): string {
 }
 
 export function concat(...bytesLikes: BytesLike[]): Uint8Array {
-  return Uint8Array.from(
-    bytesLikes.flatMap((bytes) => Array.from(bytify(bytes)))
-  );
+  const unmerged = bytesLikes.map(bytify);
+  const totalSize = unmerged.reduce((size, item) => size + item.length, 0);
+
+  const merged = new Uint8Array(totalSize);
+
+  let offset = 0;
+  unmerged.forEach((item) => {
+    merged.set(item, offset);
+    offset += item.length;
+  });
+
+  return merged;
 }
 
 // export function split(bytes: BytesLike, points: number[]): Uint8Array[] {


### PR DESCRIPTION
Resolve https://github.com/nervosnetwork/lumos/issues/374, the `concat` is used by every molecule layout and the current implementation is low performance.

This PR refactors `concat` via re-alloc a new Uint8Array and the benchmark has an improvement of about 100x


```
concat#re-construct x 21.36 ops/sec ±1.44% (40 runs sampled)
concat#re-alloc x 2,525 ops/sec ±1.73% (90 runs sampled)
```

<details><summary>benchmark.js</summary>


```ts
import Benchmark from "benchmark";
import { concat, concatViaReconstruct } from "@ckb-lumos/codec/lib/bytes";
import { randomBytes } from "crypto";

// export function concatViaReconstruct(...bytesLikes: BytesLike[]): Uint8Array {
//   return Uint8Array.from(
//     bytesLikes.flatMap((bytes) => Array.from(bytify(bytes)))
//   );
// }
//
// export function concat(...bytesLikes: BytesLike[]): Uint8Array {
//   const unmerged = bytesLikes.map(bytify);
//   const totalSize = unmerged.reduce((size, item) => size + item.length, 0);
//
//   const merged = new Uint8Array(totalSize);
//
//   let offset = 0;
//   unmerged.forEach((item) => {
//     merged.set(item, offset);
//     offset += item.length;
//   });
//
//   return merged;
// }

const bytesArr = Array.from({ length: 1000 }).map(() =>
  randomBytes(Math.ceil(1000 * Math.random()))
);

const suite = new Benchmark.Suite();

suite
  .add("concat#re-construct", () => {
    return concatViaReconstruct(...bytesArr);
  })
  .add("concat#re-alloc", () => {
    return concat(...bytesArr);
  })
  .on("cycle", function (event: any) {
    console.log(String(event.target));
  })
  .run();
```


</details>
