### PR TITLE
fix: incompatible types in indexer and rpc

### DIFF
--- a/examples/cardano-lock-namiwallet/package.json
+++ b/examples/cardano-lock-namiwallet/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@lumos-examples/cardano-lock-namiwallet",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ckb-lumos/lumos": "0.18.0",
+    "@ckb-lumos/lumos": "0.19.0-alpha.0",
     "@emurgo/cardano-message-signing-asmjs": "^1.0.1",
     "@emurgo/cardano-serialization-lib-asmjs": "^10.0.4",
     "@types/react": "^17.0.34",

--- a/examples/omni-lock-metamask/package.json
+++ b/examples/omni-lock-metamask/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@lumos-examples/omni-lock-metamask",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ckb-lumos/lumos": "0.18.0",
+    "@ckb-lumos/lumos": "0.19.0-alpha.0",
     "@types/react": "^17.0.34",
     "@types/react-dom": "^17.0.11",
     "react": "^17.0.2",

--- a/examples/omni-lock-secp256k1-blake160/package.json
+++ b/examples/omni-lock-secp256k1-blake160/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@lumos-examples/omni-lock-own-signature",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ckb-lumos/lumos": "0.18.0",
+    "@ckb-lumos/lumos": "0.19.0-alpha.0",
     "@types/react": "^17.0.34",
     "@types/react-dom": "^17.0.11",
     "react": "^17.0.2",

--- a/examples/pw-lock-metamask/package.json
+++ b/examples/pw-lock-metamask/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@lumos-examples/pw-lock-metamask",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ckb-lumos/lumos": "0.18.0",
+    "@ckb-lumos/lumos": "0.19.0-alpha.0",
     "@types/react": "^17.0.34",
     "@types/react-dom": "^17.0.11",
     "keccak": "^3.0.1",

--- a/examples/secp256k1-transfer/package.json
+++ b/examples/secp256k1-transfer/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@lumos-examples/secp256k1-transfer",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@ckb-lumos/lumos": "0.18.0",
+    "@ckb-lumos/lumos": "0.19.0-alpha.0",
     "@types/react": "^17.0.34",
     "@types/react-dom": "^17.0.11",
     "react": "^17.0.2",

--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,7 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "command": {
     "publish": {
       "access": "public"

--- a/packages/base/index.d.ts
+++ b/packages/base/index.d.ts
@@ -1,16 +1,16 @@
-import * as utils from "./src/utils";
-import * as helpers from "./src/helpers";
-import * as since from "./src/since";
-import * as values from "./src/values";
-import * as logger from "./src/logger";
-import * as blockchain from "./src/blockchain";
+import * as utils from "./lib/utils";
+import * as helpers from "./lib/helpers";
+import * as since from "./lib/since";
+import * as values from "./lib/values";
+import * as logger from "./lib/logger";
+import * as blockchain from "./lib/blockchain";
 
-export * from "./src/primitive";
-export * from "./src/api";
-export * from "./src/indexer";
+export * from "./lib/primitive";
+export * from "./lib/api";
+export * from "./lib/indexer";
 
 export { utils, helpers, since, values, logger, blockchain };
-export { SinceValidationInfo } from "./src/since";
+export { SinceValidationInfo } from "./lib/since";
 
 export interface Tip {
   blockNumber: string;

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/base",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "Base data structures and utilities used in lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
@@ -49,9 +49,9 @@
     ]
   },
   "dependencies": {
-    "@ckb-lumos/bi": "0.18.0",
-    "@ckb-lumos/codec": "0.18.0",
-    "@ckb-lumos/toolkit": "0.18.0",
+    "@ckb-lumos/bi": "^0.19.0-alpha.0",
+    "@ckb-lumos/codec": "^0.19.0-alpha.0",
+    "@ckb-lumos/toolkit": "^0.19.0-alpha.0",
     "@types/lodash.isequal": "^4.5.5",
     "blake2b": "^2.1.3",
     "js-xxhash": "^1.0.4",

--- a/packages/base/src/api.d.ts
+++ b/packages/base/src/api.d.ts
@@ -102,14 +102,15 @@ export interface Block {
   proposals: HexString[];
 }
 
+export interface LiveCell {
+  data: {
+    content: HexString;
+    hash: Hash;
+  };
+  output: Output;
+}
 export interface CellWithStatus {
-  cell: {
-    data: {
-      content: HexString;
-      hash: Hash;
-    };
-    output: Output;
-  } | null;
+  cell:  LiveCell | null;
   status: "live" | "unknown";
 }
 
@@ -159,6 +160,7 @@ export interface ProposalWindow {
 export interface Consensus {
   id: string;
   genesisHash: Hash;
+  hardforkFeatures: Array<{ rfc: string; epochNumber: string | undefined }>;
   daoTypeHash?: Hash;
   secp256k1Blake160SighashAllTypeHash?: Hash;
   secp256k1Blake160MultisigAllTypeHash?: Hash;
@@ -211,6 +213,8 @@ export interface PeerSyncState {
   lastCommonHeaderHash?: HexString;
   lastCommonHeaderNumber?: HexNumber;
   unknownHeaderListSize?: HexNumber;
+  canFetchCount?: HexNumber;
+  inflightCount?: HexNumber;
 }
 
 export interface RemoteNodeProtocol {
@@ -222,7 +226,7 @@ export interface RemoteNode {
   version: string;
   nodeId: string;
   addresses: NodeAddress[];
-  isOutbount: boolean;
+  isOutbound: boolean;
   connectedDuration: HexNumber;
   lastPingDuration?: HexNumber;
   syncState?: PeerSyncState;

--- a/packages/base/src/api.d.ts
+++ b/packages/base/src/api.d.ts
@@ -160,6 +160,7 @@ export interface ProposalWindow {
 export interface Consensus {
   id: string;
   genesisHash: Hash;
+  // added this field by: https://github.com/nervosnetwork/ckb/pull/2879
   hardforkFeatures: Array<{ rfc: string; epochNumber: string | undefined }>;
   daoTypeHash?: Hash;
   secp256k1Blake160SighashAllTypeHash?: Hash;

--- a/packages/bi/package.json
+++ b/packages/bi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/bi",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "Bigint support in lumos",
   "author": "",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",

--- a/packages/ckb-indexer/package.json
+++ b/packages/ckb-indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/ckb-indexer",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "CKB Indexer",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
@@ -19,15 +19,15 @@
     "src"
   ],
   "dependencies": {
-    "@ckb-lumos/base": "0.18.0",
-    "@ckb-lumos/bi": "0.18.0",
-    "@ckb-lumos/rpc": "0.18.0",
-    "@ckb-lumos/toolkit": "0.18.0",
+    "@ckb-lumos/base": "^0.19.0-alpha.0",
+    "@ckb-lumos/bi": "^0.19.0-alpha.0",
+    "@ckb-lumos/rpc": "^0.19.0-alpha.0",
+    "@ckb-lumos/toolkit": "^0.19.0-alpha.0",
     "cross-fetch": "^3.1.5",
     "events": "^3.3.0"
   },
   "devDependencies": {
-    "@ckb-lumos/testkit": "0.18.0",
+    "@ckb-lumos/testkit": "^0.19.0-alpha.0",
     "@types/request": "^2.48.8",
     "@types/sinon": "^10.0.6",
     "find-process": "^1.4.7",

--- a/packages/ckb-indexer/src/paramsFormatter.ts
+++ b/packages/ckb-indexer/src/paramsFormatter.ts
@@ -1,9 +1,26 @@
 import { Script } from "@ckb-lumos/base";
 import type * as RPCType from "./rpcType";
+import { SearchKey, SearchFilter } from "./type";
 
 const toScript = (data: Script): RPCType.Script => ({
   code_hash: data.codeHash,
   hash_type: data.hashType,
   args: data.args,
 });
-export { toScript };
+
+const toSearchFilter = (data: SearchFilter): RPCType.SearchFilter => {
+  return {
+    script: data.script ? toScript(data.script) : data.script,
+    output_data_len_range: data.outputDataLenRange,
+    output_capacity_range: data.outputCapacityRange,
+    block_range: data.blockRange,
+  };
+};
+
+const toSearchKey = (data: SearchKey): RPCType.SearchKey => ({
+  script: toScript(data.script),
+  script_type: data.scriptType,
+  filter: data.filter ? toSearchFilter(data.filter) : data.filter,
+});
+
+export { toScript, toSearchKey, toSearchFilter };

--- a/packages/ckb-indexer/src/resultFormatter.ts
+++ b/packages/ckb-indexer/src/resultFormatter.ts
@@ -1,6 +1,7 @@
 import { OutPoint, Script } from "@ckb-lumos/base";
 import type * as IndexerType from "./indexerType";
 import type * as RPCType from "./rpcType";
+import { SearchFilter, SearchKey } from "./type";
 
 const toTip = (tip: RPCType.Tip): IndexerType.Tip => ({
   blockHash: tip.block_hash,
@@ -21,4 +22,26 @@ const toCellOutPut = (data: RPCType.CellOutput): IndexerType.CellOutput => ({
   type: data.type ? toScript(data.type) : undefined,
 });
 
-export { toTip, toScript, toOutPoint, toCellOutPut };
+const toSearchFilter = (data: RPCType.SearchFilter): SearchFilter => {
+  return {
+    script: data.script ? toScript(data.script) : data.script,
+    outputDataLenRange: data.output_data_len_range,
+    outputCapacityRange: data.output_capacity_range,
+    blockRange: data.block_range,
+  };
+};
+
+const toSearchKey = (data: RPCType.SearchKey): SearchKey => ({
+  script: toScript(data.script),
+  scriptType: data.script_type,
+  filter: data.filter ? toSearchFilter(data.filter) : data.filter,
+});
+
+export {
+  toTip,
+  toScript,
+  toOutPoint,
+  toCellOutPut,
+  toSearchKey,
+  toSearchFilter,
+};

--- a/packages/ckb-indexer/src/rpc.ts
+++ b/packages/ckb-indexer/src/rpc.ts
@@ -6,6 +6,7 @@ import {
   SearchKey,
 } from "./type";
 import fetch from "cross-fetch";
+import { toSearchKey } from "./paramsFormatter";
 
 export class RPC {
   private uri: string;
@@ -27,7 +28,7 @@ export class RPC {
     limit: HexString,
     cursor?: string
   ): Promise<GetLiveCellsResult> {
-    const params = [searchKey, order, limit, cursor];
+    const params = [toSearchKey(searchKey), order, limit, cursor];
     return utils.deepCamel(await request(this.uri, "get_cells", params));
   }
   async getTransactions(
@@ -36,7 +37,7 @@ export class RPC {
     limit: HexString,
     cursor?: string
   ): Promise<IndexerTransactionList> {
-    const params = [searchKey, order, limit, cursor];
+    const params = [toSearchKey(searchKey), order, limit, cursor];
     return utils.deepCamel(await request(this.uri, "get_transactions", params));
   }
   async getIndexerInfo(): Promise<string> {

--- a/packages/ckb-indexer/src/rpcType.ts
+++ b/packages/ckb-indexer/src/rpcType.ts
@@ -1,4 +1,4 @@
-import { HexString, HexNumber, Hash } from "@ckb-lumos/base";
+import { HexString, HexNumber, Hash, Hexadecimal } from "@ckb-lumos/base";
 
 export type Tip = {
   block_hash: HexNumber;
@@ -18,3 +18,18 @@ export type CellOutput = {
   lock: Script;
   type?: Script;
 };
+
+export type HexadecimalRange = [Hexadecimal, Hexadecimal];
+export type ScriptType = "type" | "lock";
+
+export interface SearchFilter {
+  script?: Script;
+  output_data_len_range?: HexadecimalRange; //empty
+  output_capacity_range?: HexadecimalRange; //empty
+  block_range?: HexadecimalRange; //fromBlock-toBlock
+}
+export interface SearchKey {
+  script: Script;
+  script_type: ScriptType;
+  filter?: SearchFilter;
+}

--- a/packages/ckb-indexer/src/services.ts
+++ b/packages/ckb-indexer/src/services.ts
@@ -1,15 +1,10 @@
 import { utils, HexString, ScriptWrapper, Script } from "@ckb-lumos/base";
-import {
-  CKBIndexerQueryOptions,
-  HexadecimalRange,
-  SearchFilter,
-  ScriptType,
-  SearchKey,
-} from "./type";
+import { CKBIndexerQueryOptions, SearchKey } from "./type";
 import fetch from "cross-fetch";
 import { BI } from "@ckb-lumos/bi";
 import { toScript } from "./paramsFormatter";
 import type * as RPCType from "./rpcType";
+import { toSearchKey } from "./resultFormatter";
 
 function instanceOfScriptWrapper(object: unknown): object is ScriptWrapper {
   return typeof object === "object" && object != null && "script" in object;
@@ -22,8 +17,8 @@ const UnwrapScriptWrapper = (inputScript: ScriptWrapper | Script): Script => {
 };
 const generateSearchKey = (queries: CKBIndexerQueryOptions): SearchKey => {
   let script: RPCType.Script | undefined = undefined;
-  const filter: SearchFilter = {};
-  let script_type: ScriptType | undefined = undefined;
+  const filter: RPCType.SearchFilter = {};
+  let script_type: RPCType.ScriptType | undefined = undefined;
   if (queries.lock) {
     const lock = UnwrapScriptWrapper(queries.lock);
     script = toScript(lock);
@@ -37,7 +32,7 @@ const generateSearchKey = (queries: CKBIndexerQueryOptions): SearchKey => {
     script = toScript(type);
     script_type = "type";
   }
-  let block_range: HexadecimalRange | null = null;
+  let block_range: RPCType.HexadecimalRange | null = null;
   if (queries.fromBlock && queries.toBlock) {
     //toBlock+1 cause toBlock need to be included
     block_range = [
@@ -60,11 +55,11 @@ const generateSearchKey = (queries: CKBIndexerQueryOptions): SearchKey => {
   if (!script_type) {
     throw new Error("script_type must be provided");
   }
-  return {
+  return toSearchKey({
     script,
     script_type,
     filter,
-  };
+  });
 };
 
 const getHexStringBytes = (hexString: HexString): number => {

--- a/packages/ckb-indexer/src/type.ts
+++ b/packages/ckb-indexer/src/type.ts
@@ -11,7 +11,6 @@ import {
 } from "@ckb-lumos/base";
 import { EventEmitter } from "events";
 import { BIish } from "@ckb-lumos/bi";
-import type * as RPCType from "./rpcType";
 
 export type ScriptType = "type" | "lock";
 export type Order = "asc" | "desc";
@@ -24,17 +23,16 @@ export interface CKBIndexerQueryOptions extends QueryOptions {
 
 export type HexadecimalRange = [Hexadecimal, Hexadecimal];
 export interface SearchFilter {
-  script?: RPCType.Script;
-  output_data_len_range?: HexadecimalRange; //empty
-  output_capacity_range?: HexadecimalRange; //empty
-  block_range?: HexadecimalRange; //fromBlock-toBlock
+  script?: Script;
+  outputDataLenRange?: HexadecimalRange; //empty
+  outputCapacityRange?: HexadecimalRange; //empty
+  blockRange?: HexadecimalRange; //fromBlock-toBlock
 }
 export interface SearchKey {
-  script: RPCType.Script;
-  script_type: ScriptType;
+  script: Script;
+  scriptType: ScriptType;
   filter?: SearchFilter;
 }
-
 export interface GetLiveCellsResult {
   lastCursor: string;
   objects: IndexerCell[];

--- a/packages/ckb-indexer/tests/paramsFormatter.unit.test.ts
+++ b/packages/ckb-indexer/tests/paramsFormatter.unit.test.ts
@@ -1,0 +1,36 @@
+import test from "ava";
+import { toSearchKey } from "../src/paramsFormatter";
+import { SearchKey } from "../src/type";
+import type * as RPCType from "../src/rpcType";
+
+test("should toSearchKey works fine", async (t) => {
+  const query: SearchKey = {
+    script: {
+      codeHash:
+        "0x123456789012345678901234567890123456789001234567890012345678901234",
+      hashType: "data",
+      args: "0x1234567890123456789012345678901234567890",
+    },
+    scriptType: "lock",
+    filter: {
+      outputDataLenRange: ["0x1", "0x2"],
+    },
+  };
+  const expected: RPCType.SearchKey = {
+    script: {
+      args: "0x1234567890123456789012345678901234567890",
+      code_hash:
+        "0x123456789012345678901234567890123456789001234567890012345678901234",
+      hash_type: "data",
+    },
+    script_type: "lock",
+    filter: {
+      script: undefined,
+      block_range: undefined,
+      output_capacity_range: undefined,
+      output_data_len_range: ["0x1", "0x2"],
+    },
+  };
+
+  t.deepEqual(toSearchKey(query), expected);
+});

--- a/packages/ckb-indexer/tests/resultFormatter.unit.test.ts
+++ b/packages/ckb-indexer/tests/resultFormatter.unit.test.ts
@@ -1,0 +1,35 @@
+import test from "ava";
+import { toSearchKey } from "../src/resultFormatter";
+import { SearchKey } from "../src/type";
+import type * as RPCType from "../src/rpcType";
+
+test("should toSearchKey works fine", async (t) => {
+  const query: RPCType.SearchKey = {
+    script: {
+      args: "0x1234567890123456789012345678901234567890",
+      code_hash:
+        "0x123456789012345678901234567890123456789001234567890012345678901234",
+      hash_type: "data",
+    },
+    script_type: "lock",
+    filter: {
+      output_data_len_range: ["0x1", "0x2"],
+    },
+  };
+  const expected: SearchKey = {
+    script: {
+      codeHash:
+        "0x123456789012345678901234567890123456789001234567890012345678901234",
+      hashType: "data",
+      args: "0x1234567890123456789012345678901234567890",
+    },
+    scriptType: "lock",
+    filter: {
+      script: undefined,
+      outputCapacityRange: undefined,
+      blockRange: undefined,
+      outputDataLenRange: ["0x1", "0x2"],
+    },
+  };
+  t.deepEqual(toSearchKey(query), expected);
+});

--- a/packages/ckb-indexer/tests/service.unit.test.ts
+++ b/packages/ckb-indexer/tests/service.unit.test.ts
@@ -1,0 +1,33 @@
+import test from "ava";
+import { SearchKey } from "../src/type";
+import { generateSearchKey } from "../src/services";
+
+test("should generateSearchKey works fine", async (t) => {
+  const expected: SearchKey = {
+    script: {
+      codeHash:
+        "0x123456789012345678901234567890123456789001234567890012345678901234",
+      hashType: "data",
+      args: "0x1234567890123456789012345678901234567890",
+    },
+    scriptType: "lock",
+    filter: {
+      script: undefined,
+      outputCapacityRange: undefined,
+      blockRange: undefined,
+      outputDataLenRange: ["0x1", "0x2"],
+    },
+  };
+  t.deepEqual(
+    generateSearchKey({
+      lock: {
+        codeHash:
+          "0x123456789012345678901234567890123456789001234567890012345678901234",
+        hashType: "data",
+        args: "0x1234567890123456789012345678901234567890",
+      },
+      outputDataLenRange: ["0x1", "0x2"],
+    }),
+    expected
+  );
+});

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/codec",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "Make your own molecule binding in JavaScript(TypeScript)",
   "author": "",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
@@ -30,7 +30,7 @@
     "release": "npm publish"
   },
   "dependencies": {
-    "@ckb-lumos/bi": "0.18.0"
+    "@ckb-lumos/bi": "^0.19.0-alpha.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/common-scripts/package.json
+++ b/packages/common-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/common-scripts",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "Common script support in lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
@@ -19,13 +19,13 @@
     "src"
   ],
   "dependencies": {
-    "@ckb-lumos/base": "0.18.0",
-    "@ckb-lumos/bi": "0.18.0",
-    "@ckb-lumos/config-manager": "0.18.0",
-    "@ckb-lumos/helpers": "0.18.0",
-    "@ckb-lumos/rpc": "0.18.0",
-    "@ckb-lumos/toolkit": "0.18.0",
-    "@ckb-lumos/codec": "0.18.0",
+    "@ckb-lumos/base": "^0.19.0-alpha.0",
+    "@ckb-lumos/bi": "^0.19.0-alpha.0",
+    "@ckb-lumos/codec": "^0.19.0-alpha.0",
+    "@ckb-lumos/config-manager": "^0.19.0-alpha.0",
+    "@ckb-lumos/helpers": "^0.19.0-alpha.0",
+    "@ckb-lumos/rpc": "^0.19.0-alpha.0",
+    "@ckb-lumos/toolkit": "^0.19.0-alpha.0",
     "immutable": "^4.0.0-rc.12"
   },
   "repository": {

--- a/packages/config-manager/package.json
+++ b/packages/config-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/config-manager",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "Config manager for lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
@@ -36,9 +36,9 @@
     "url": "https://github.com/nervosnetwork/lumos/issues"
   },
   "dependencies": {
-    "@ckb-lumos/base": "0.18.0",
-    "@ckb-lumos/bi": "0.18.0",
-    "@ckb-lumos/codec": "0.18.0",
+    "@ckb-lumos/base": "^0.19.0-alpha.0",
+    "@ckb-lumos/bi": "^0.19.0-alpha.0",
+    "@ckb-lumos/codec": "^0.19.0-alpha.0",
     "@types/deep-freeze-strict": "^1.1.0",
     "deep-freeze-strict": "^1.1.1"
   },

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@ckb-lumos/debugger",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "ckb-standard-debugger wrapper for lumos, check tx without launching a full node",
   "author": "",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
@@ -21,12 +21,12 @@
     "contracts"
   ],
   "dependencies": {
-    "@ckb-lumos/base": "*",
-    "@ckb-lumos/bi": "*",
-    "@ckb-lumos/codec": "*",
-    "@ckb-lumos/rpc": "*",
-    "@ckb-lumos/config-manager": "*",
-    "@ckb-lumos/helpers": "*",
+    "@ckb-lumos/base": "^0.19.0-alpha.0",
+    "@ckb-lumos/bi": "^0.19.0-alpha.0",
+    "@ckb-lumos/codec": "^0.19.0-alpha.0",
+    "@ckb-lumos/config-manager": "^0.19.0-alpha.0",
+    "@ckb-lumos/helpers": "^0.19.0-alpha.0",
+    "@ckb-lumos/rpc": "^0.19.0-alpha.0",
     "@types/download": "^8.0.1",
     "@types/object-hash": "^2.2.1",
     "debug": "^4.3.4",
@@ -35,7 +35,7 @@
     "object-hash": "^3.0.0"
   },
   "devDependencies": {
-    "@ckb-lumos/experiment-tx-assembler": "*"
+    "@ckb-lumos/experiment-tx-assembler": "^0.19.0-alpha.0"
   },
   "bin": {
     "download-ckb-debugger": "bin/download-ckb-debugger.js"

--- a/packages/experiment-tx-assembler/package.json
+++ b/packages/experiment-tx-assembler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/experiment-tx-assembler",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
   "license": "MIT",
@@ -21,10 +21,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@ckb-lumos/base": "0.18.0",
-    "@ckb-lumos/config-manager": "0.18.0",
-    "@ckb-lumos/helpers": "0.18.0",
-    "@ckb-lumos/toolkit": "0.18.0"
+    "@ckb-lumos/base": "^0.19.0-alpha.0",
+    "@ckb-lumos/config-manager": "^0.19.0-alpha.0",
+    "@ckb-lumos/helpers": "^0.19.0-alpha.0",
+    "@ckb-lumos/toolkit": "^0.19.0-alpha.0"
   },
   "repository": {
     "type": "git",

--- a/packages/hd-cache/package.json
+++ b/packages/hd-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/hd-cache",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "HD wallet cache in lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
@@ -19,12 +19,12 @@
     "src"
   ],
   "dependencies": {
-    "@ckb-lumos/base": "0.18.0",
-    "@ckb-lumos/bi": "0.18.0",
-    "@ckb-lumos/ckb-indexer": "0.18.0",
-    "@ckb-lumos/config-manager": "0.18.0",
-    "@ckb-lumos/hd": "0.18.0",
-    "@ckb-lumos/rpc": "0.18.0",
+    "@ckb-lumos/base": "^0.19.0-alpha.0",
+    "@ckb-lumos/bi": "^0.19.0-alpha.0",
+    "@ckb-lumos/ckb-indexer": "^0.19.0-alpha.0",
+    "@ckb-lumos/config-manager": "^0.19.0-alpha.0",
+    "@ckb-lumos/hd": "^0.19.0-alpha.0",
+    "@ckb-lumos/rpc": "^0.19.0-alpha.0",
     "immutable": "^4.0.0-rc.12"
   },
   "repository": {

--- a/packages/hd/package.json
+++ b/packages/hd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/hd",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "HD wallet manager in lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
@@ -19,8 +19,8 @@
     "src"
   ],
   "dependencies": {
-    "@ckb-lumos/base": "0.18.0",
-    "@ckb-lumos/bi": "0.18.0",
+    "@ckb-lumos/base": "^0.19.0-alpha.0",
+    "@ckb-lumos/bi": "^0.19.0-alpha.0",
     "bn.js": "^5.1.3",
     "elliptic": "^6.5.4",
     "sha3": "^2.1.3",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/helpers",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "Helper functions for working with CKB",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
@@ -37,10 +37,10 @@
     "url": "https://github.com/nervosnetwork/lumos/issues"
   },
   "dependencies": {
-    "@ckb-lumos/base": "0.18.0",
-    "@ckb-lumos/bi": "0.18.0",
-    "@ckb-lumos/config-manager": "0.18.0",
-    "@ckb-lumos/toolkit": "0.18.0",
+    "@ckb-lumos/base": "^0.19.0-alpha.0",
+    "@ckb-lumos/bi": "^0.19.0-alpha.0",
+    "@ckb-lumos/config-manager": "^0.19.0-alpha.0",
+    "@ckb-lumos/toolkit": "^0.19.0-alpha.0",
     "bech32": "^2.0.0",
     "immutable": "^4.0.0-rc.12"
   },

--- a/packages/lumos/package.json
+++ b/packages/lumos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/lumos",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "A root package for Lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
@@ -37,15 +37,15 @@
     "url": "https://github.com/nervosnetwork/lumos/issues"
   },
   "dependencies": {
-    "@ckb-lumos/base": "0.18.0",
-    "@ckb-lumos/bi": "0.18.0",
-    "@ckb-lumos/ckb-indexer": "0.18.0",
-    "@ckb-lumos/common-scripts": "0.18.0",
-    "@ckb-lumos/config-manager": "0.18.0",
-    "@ckb-lumos/hd": "0.18.0",
-    "@ckb-lumos/helpers": "0.18.0",
-    "@ckb-lumos/rpc": "0.18.0",
-    "@ckb-lumos/toolkit": "0.18.0"
+    "@ckb-lumos/base": "^0.19.0-alpha.0",
+    "@ckb-lumos/bi": "^0.19.0-alpha.0",
+    "@ckb-lumos/ckb-indexer": "^0.19.0-alpha.0",
+    "@ckb-lumos/common-scripts": "^0.19.0-alpha.0",
+    "@ckb-lumos/config-manager": "^0.19.0-alpha.0",
+    "@ckb-lumos/hd": "^0.19.0-alpha.0",
+    "@ckb-lumos/helpers": "^0.19.0-alpha.0",
+    "@ckb-lumos/rpc": "^0.19.0-alpha.0",
+    "@ckb-lumos/toolkit": "^0.19.0-alpha.0"
   },
   "devDependencies": {
     "buffer": "^6.0.3",

--- a/packages/rpc/CHANGELOG.md
+++ b/packages/rpc/CHANGELOG.md
@@ -1,7 +1,21 @@
-# Changelog
+# Change Log
 
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [0.19.0-alpha.0](https://github.com/nervosnetwork/lumos/compare/v0.18.0...v0.19.0-alpha.0) (2022-08-11)
+
+
+* refactor!: camelize exposed APIs (#378) ([7c17f90](https://github.com/nervosnetwork/lumos/commit/7c17f901257b15934339022730db05c6912914f5)), closes [#378](https://github.com/nervosnetwork/lumos/issues/378)
+
+
+### BREAKING CHANGES
+
+* all exposed API are changed from snake-case to camel-case
+
+
+
+
 
 ## [0.103.1](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.102.3...v0.103.1) (2022-05-31)
 

--- a/packages/rpc/__tests__/formatters/params.fixtures.json
+++ b/packages/rpc/__tests__/formatters/params.fixtures.json
@@ -33,10 +33,6 @@
   ],
   "toOutPoint": [
     {
-      "param": null,
-      "expected": null
-    },
-    {
       "param": {
         "txHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "index": "0xffffffff"
@@ -45,10 +41,6 @@
         "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "index": "0xffffffff"
       }
-    },
-    {
-      "param": null,
-      "expected": null
     }
   ],
   "toDepType": [
@@ -62,37 +54,6 @@
     }
   ],
   "toCellDep": [
-    {
-      "param": null,
-      "expected": null
-    },
-    {
-      "param": {
-        "depType": "depGroup"
-      },
-      "expected": {
-        "dep_type": "dep_group"
-      }
-    },
-    {
-      "param": {
-        "outPoint": null
-      },
-      "expected": {
-        "out_point": null,
-        "dep_type": "code"
-      }
-    },
-    {
-      "param": {
-        "outPoint": null,
-        "depType": "depGroup"
-      },
-      "expected": {
-        "out_point": null,
-        "dep_type": "dep_group"
-      }
-    },
     {
       "param": {
         "outPoint": {
@@ -113,20 +74,6 @@
 
   "toInput": [
     {
-      "param": null,
-      "expected": null
-    },
-    {
-      "param": {
-        "previousOutput": null,
-        "since": "0x0"
-      },
-      "expected": {
-        "previous_output": null,
-        "since": "0x0"
-      }
-    },
-    {
       "param": {
         "previousOutput": {
           "txHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -144,10 +91,6 @@
     }
   ],
   "toOutput": [
-    {
-      "param": null,
-      "expected": null
-    },
     {
       "param": {
         "capacity": "0x48c27395000",
@@ -253,7 +196,10 @@
         "headerDeps": [],
         "inputs": [
           {
-            "previousOutput": null,
+            "previousOutput": {
+              "txHash": "0x00000000000000000000000000000000000000000000000000000000000000001",
+              "index": "0xfffffff1"
+            },
             "since": "0x0"
           },
           {
@@ -292,7 +238,10 @@
         "header_deps": [],
         "inputs": [
           {
-            "previous_output": null,
+            "previous_output": {
+              "tx_hash": "0x00000000000000000000000000000000000000000000000000000000000000001",
+              "index": "0xfffffff1"
+            },
             "since": "0x0"
           },
           {

--- a/packages/rpc/__tests__/formatters/result.fixtures.json
+++ b/packages/rpc/__tests__/formatters/result.fixtures.json
@@ -117,10 +117,6 @@
   ],
   "toOutPoint": [
     {
-      "result": null,
-      "expected": null
-    },
-    {
       "result": {
         "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "index": "4294967295"
@@ -132,37 +128,6 @@
     }
   ],
   "toCellDep": [
-    {
-      "result": null,
-      "expected": null
-    },
-    {
-      "result": {
-        "dep_type": "dep_group"
-      },
-      "expected": {
-        "depType": "depGroup"
-      }
-    },
-    {
-      "result": {
-        "out_point": null
-      },
-      "expected": {
-        "outPoint": null,
-        "depType": "code"
-      }
-    },
-    {
-      "result": {
-        "out_point": null,
-        "dep_type": "code"
-      },
-      "expected": {
-        "outPoint": null,
-        "depType": "code"
-      }
-    },
     {
       "result": {
         "out_point": {

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@ckb-lumos/bi": "^0.19.0-alpha.0",
+    "@ckb-lumos/base": "^0.19.0-alpha.0",
     "axios": "0.21.4",
     "tslib": "2.3.1"
   },

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/rpc",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "RPC module for CKB",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
   "license": "MIT",
@@ -38,7 +38,7 @@
     "release": "npm publish"
   },
   "dependencies": {
-    "@ckb-lumos/bi": "0.18.0",
+    "@ckb-lumos/bi": "^0.19.0-alpha.0",
     "axios": "0.21.4",
     "tslib": "2.3.1"
   },

--- a/packages/rpc/src/paramsFormatter.ts
+++ b/packages/rpc/src/paramsFormatter.ts
@@ -50,10 +50,7 @@ export const formatter = {
       ...rest,
     };
   },
-  toOutPoint: (
-    outPoint: CKBComponents.OutPoint | undefined
-  ): RPC.OutPoint | undefined => {
-    if (!outPoint) return outPoint;
+  toOutPoint: (outPoint: CKBComponents.OutPoint): RPC.OutPoint => {
     const { txHash, index, ...rest } = outPoint;
     return {
       tx_hash: formatter.toHash(txHash),
@@ -88,7 +85,7 @@ export const formatter = {
   },
   toCellDep: (cellDep: CKBComponents.CellDep): RPC.CellDep => {
     if (!cellDep) return cellDep;
-    const { outPoint = undefined, depType = "code", ...rest } = cellDep;
+    const { outPoint, depType = "code", ...rest } = cellDep;
     return {
       out_point: formatter.toOutPoint(outPoint),
       dep_type: formatter.toDepType(depType),

--- a/packages/rpc/src/resultFormatter.ts
+++ b/packages/rpc/src/resultFormatter.ts
@@ -56,10 +56,7 @@ const toOutput = (output: RPC.CellOutput): CKBComponents.CellOutput => {
     ...rest,
   };
 };
-const toOutPoint = (
-  outPoint: RPC.OutPoint | undefined
-): CKBComponents.OutPoint | undefined => {
-  if (!outPoint) return outPoint;
+const toOutPoint = (outPoint: RPC.OutPoint): CKBComponents.OutPoint => {
   const { tx_hash: txHash, ...rest } = outPoint;
   return {
     txHash,
@@ -75,11 +72,7 @@ const toDepType = (type: RPC.DepType): CKBComponents.DepType => {
 
 const toCellDep = (cellDep: RPC.CellDep): CKBComponents.CellDep => {
   if (!cellDep) return cellDep;
-  const {
-    out_point: outPoint = undefined,
-    dep_type = "code",
-    ...rest
-  } = cellDep;
+  const { out_point: outPoint, dep_type = "code", ...rest } = cellDep;
   return {
     outPoint: toOutPoint(outPoint),
     depType: toDepType(dep_type),

--- a/packages/rpc/src/types/api.ts
+++ b/packages/rpc/src/types/api.ts
@@ -1,3 +1,4 @@
+import type * as api from "@ckb-lumos/base";
 /**
  * @see https://github.com/nervosnetwork/ckb/blob/develop/protocol/src/protocol.fbs for more infGomation
  */
@@ -56,131 +57,43 @@ export namespace CKBComponents {
   /**
    * RPC Units
    */
-
-  /* eslint-disable max-len */
-  /**
-   * @typedef Script, lock or type script
-   * @description Script, the script model in CKB. CKB scripts use UNIX standard execution environment.
-   *              Each script binary should contain a main function with the following signature `int main(int argc, char* argv[]);`.
-   *              CKB will concat  `args`, then use the concatenated array to fill `argc/argv` part, then start the script execution.
-   *              Upon termination, the executed `main` function here will provide a return code,
-   *              `0` means the script execution succeeds, other values mean the execution fails.
-   * @property args, arguments.
-   * @property codeHash, point to its dependency, if the referred dependency is listed in the deps field in a transaction,
-   *                     the codeHash means the hash of the referred cell's data.
-   * @property hashType, a enumerate indicates the type of the code which is referened by the code hash
-   */
-  /* eslint-enable max-len */
-  export interface Script {
-    args: Bytes;
-    codeHash: Hash256;
-    hashType: ScriptHashType;
-  }
-
-  /**
-   * @typedef CellInput, cell input in a transaction
-   * @property previousOutput, point to its P1 cell
-   * @property since, a parameter to prevent a cell to be spent before a centain block timestamp or a block number,
-   *           [RFC](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0017-tx-valid-since/0017-tx-valid-since.md)
-   */
-  export interface CellInput {
-    previousOutput: OutPoint | undefined;
-    since: Since;
-  }
-
-  /**
-   * @typedef CellOutput, cell output in a transaction
-   * @property capacity, the capacity of the genereated P1 cell
-   * @property lock, lock script
-   * @property type, type script
-   */
-  export interface CellOutput {
-    capacity: Capacity;
-    lock: Script;
-    type?: Script | undefined;
-  }
-
-  /**
-   * @typedef OutPoint, used to refer a generated cell by transaction hash and output index
-   * @property hash, transaction hash
-   * @property index, index of cell output
-   */
-  export interface OutPoint {
-    txHash: Hash256;
-    index: Index;
-  }
-
-  /**
-   * @typeof CellDep, cell dependencies in a transaction
-   * @property outPoint, the out point of the cell dependency
-   * @property depType, indicate if the data of the cell containing a group of dependencies
-   */
-  export interface CellDep {
-    outPoint: OutPoint | undefined;
-    depType: DepType;
-  }
-
   export type Witness = Bytes;
 
-  /**
-   * @typedef RawTransaction, raw transaction object
-   * @property version, transaction version
-   * @property cellDeps, cell deps used in the transaction
-   * @property headerDeps, header deps referenced to a specific block used in the transaction
-   * @property inputs, cell inputs in the transaction
-   * @property outputs, cell outputs in the transaction
-   * @property witnesses, segrated witnesses
-   * @property outputsData, data referenced by scripts
-   */
-  export interface RawTransaction {
-    version: Version;
-    cellDeps: CellDep[];
-    headerDeps: Hash256[];
-    inputs: CellInput[];
-    outputs: CellOutput[];
-    witnesses: Witness[];
-    outputsData: Bytes[];
-  }
+  export type Script = api.Script;
+  export type CellInput = api.Input;
+  export type CellOutput = api.Output;
+  export type Cell = CellOutput;
+  export type OutPoint = api.OutPoint;
+  export type CellDep = api.CellDep;
+  export type RawTransaction = api.RawTransaction & { witnesses: Witness[] };
+  export type Transaction = Required<api.Transaction>;
+  export type TransactionWithStatus = api.TransactionWithStatus;
+  export type BlockHeader = api.Header;
+  export type Block = api.Block;
+  export type UncleBlock = api.UncleBlock;
+  export type LiveCell = api.LiveCell;
+  export type AlertMessage = api.AlertMessage;
+  export type BlockchainInfo = api.ChainInfo;
+  export type LocalNodeInfo = api.LocalNode;
+  export type RemoteNodeInfo = api.RemoteNode;
+  export type TxPoolInfo = api.TxPoolInfo;
+  export type Epoch = api.Epoch;
+  export type RunDryResult = api.DryRunResult;
+  export type BannedAddress = api.BannedAddr;
+  export type WitnessArgs = api.WitnessArgs;
+  export type BlockEconomicState = api.BlockEconomicState;
+  export type SyncState = api.SyncState;
+  export type TransactionProof = api.TransactionProof;
+  export type TxVerbosity = api.TxVerbosity;
+  export type TxPoolVerbosity = api.TxPoolVerbosity;
+  export type RawTxPool = api.RawTxPool;
+  export type Consensus = api.Consensus;
 
-  /**
-   * @typedef Transaction, transaction object
-   * @extends RawTransaction
-   * @property hash, transaction hash
-   */
-  export interface Transaction extends RawTransaction {
-    hash: Hash256;
-  }
-
-  export interface TransactionWithStatus {
-    transaction: Transaction;
-    txStatus:
-      | {
-          blockHash: Hash256;
-          status: TransactionStatus.Committed;
-        }
-      | {
-          blockHash: undefined;
-          status: TransactionStatus.Pending | TransactionStatus.Proposed;
-        };
-  }
-
-  /**
-   * @typeof TransactionPoint
-   * @property blockNumber
-   * @property index
-   * @property txHash
-   */
   export interface TransactionPoint {
     blockNumber: BlockNumber;
     index: Index;
     txHash: Hash256;
   }
-
-  /**
-   * @TransactionByLockHash
-   * @property consumedBy
-   * @property createdBy
-   */
   export interface TransactionByLockHash {
     consumedBy: undefined | TransactionPoint;
     createdBy: TransactionPoint;
@@ -188,96 +101,14 @@ export namespace CKBComponents {
 
   export type TransactionsByLockHash = TransactionByLockHash[];
 
-  /**
-   * @typedef BlockHeader, header of a block
-   * @property compactTarget
-   * @property dao
-   * @property epoch
-   * @property hash
-   * @property number
-   * @property parentHash
-   * @property proposalsHash
-   * @property nonce
-   * @property timestamp
-   * @property transactionsRoot
-   * @property extraHash
-   * @property version
-   */
-  export interface BlockHeader {
-    compactTarget: Hash;
-    dao: DAO;
-    epoch: EpochInHeader;
-    hash: Hash256;
-    number: BlockNumber;
-    parentHash: Hash256;
-    proposalsHash: Hash256;
-    nonce: Nonce;
-    timestamp: Timestamp;
-    transactionsRoot: Hash256;
-    extraHash: Hash256;
-    version: Version;
+  export interface FeeRate {
+    feeRate: string;
   }
-
-  /**
-   * @typedef UncleBlock, uncle block object
-   * @property header, block header
-   * @property proposals
-   */
-
-  export interface UncleBlock {
-    header: BlockHeader;
-    proposals: ProposalShortId[];
-  }
-
-  /**
-   * @typedef Block, block object
-   * @property header, block header
-   * @property uncles, uncle blocks
-   * @property transactions
-   * @property proposals
-   * @property extension
-   */
-  export interface Block {
-    header: BlockHeader;
-    uncles: UncleBlock[];
-    transactions: Transaction[];
-    proposals: ProposalShortId[];
-    extension?: JsonBytes | undefined;
-  }
-
-  /**
-   * @typedef Cell, cell object
-   * @property capacty, cell capacity
-   * @property lock, lock hash
-   */
-  export type Cell = CellOutput;
-
-  /**
-   * @typeof Live Cell
-   * @property data, the data and data hash of the live cell
-   * @property output, the previous cell the live cell derives from
-   */
-
-  export interface LiveCell {
-    data?: {
-      content: Hash;
-      hash: Hash256;
-    };
-    output: CellOutput;
-  }
-
-  /**
-   * @typedef Cell, cell object
-   * @property capacty, cell capacity
-   * @property lock, lock hash
-   * @property outPoint
-   */
-
   export interface CellIncludingOutPoint {
     blockHash: Hash256;
     capacity: Capacity;
     lock: Script;
-    outPoint: OutPoint | undefined;
+    outPoint: OutPoint;
     cellbase: boolean;
     outputDataLen: string;
   }
@@ -302,83 +133,10 @@ export namespace CKBComponents {
 
   export type LiveCellsByLockHash = LiveCellByLockHash[];
 
-  export interface AlertMessage {
-    id: string;
-    priority: string;
-    noticeUntil: Timestamp;
-    message: string;
-  }
-
-  export interface BlockchainInfo {
-    isInitialBlockDownload: boolean;
-    epoch: string;
-    difficulty: string;
-    medianTime: string;
-    chain: string;
-    alerts: AlertMessage[];
-  }
-
-  export interface LocalNodeInfo {
-    active: boolean;
-    addresses: Record<"address" | "score", string>[];
-    connections: string;
-    nodeId: string;
-    protocols: { id: string; name: string; supportVersions: string[] }[];
-    version: string;
-  }
-
-  export interface RemoteNodeInfo {
-    addresses: Record<"address" | "score", string>[];
-    connectedDuration: string;
-    isOutbound: boolean;
-    lastPingDuration: string;
-    nodeId: string;
-    protocols: Record<"id" | "version", string>[];
-    syncState: Record<
-      | "bestKnownHeaderHash"
-      | "bestKnownHeaderNumber"
-      | "canFetchCount"
-      | "inflightCount"
-      | "lastCommonHeaderHash"
-      | "lastCommonHeaderNumber"
-      | "unknownHeaderListSize",
-      string | undefined
-    >;
-    version: string;
-  }
-
   export interface PeersState {
     lastUpdated: string;
     blocksInFlight: string;
     peer: string;
-  }
-
-  export interface TxPoolInfo {
-    lastTxsUpdatedAt: Timestamp;
-    minFeeRate: string;
-    orphan: Count;
-    pending: Count;
-    proposed: Count;
-    tipHash: Hash256;
-    tipNumber: BlockNumber;
-    totalTxCycles: Cycles;
-    totalTxSize: Size;
-  }
-
-  export enum CapacityUnit {
-    Shannon = 1,
-    Byte = 100000000,
-  }
-
-  export interface Epoch {
-    compactTarget: Hash;
-    length: string;
-    number: string;
-    startNumber: string;
-  }
-
-  export interface RunDryResult {
-    cycles: Cycles;
   }
 
   export interface LockHashIndexState {
@@ -389,13 +147,6 @@ export namespace CKBComponents {
 
   export type LockHashIndexStates = LockHashIndexState[];
 
-  export interface BannedAddress {
-    address: string;
-    banReason: string;
-    banUntil: Timestamp;
-    createdAt: Timestamp;
-  }
-
   export type BannedAddresses = BannedAddress[];
 
   export interface CellbaseOutputCapacityDetails {
@@ -404,18 +155,6 @@ export namespace CKBComponents {
     secondary: string;
     total: string;
     txFee: string;
-  }
-
-  export interface FeeRate {
-    feeRate: string;
-  }
-
-  export type BytesOpt = Bytes | undefined;
-
-  export interface WitnessArgs {
-    lock: BytesOpt; // witness for lock script in input
-    inputType: BytesOpt; // witness for type script in input
-    outputType: BytesOpt; // witness for type script in output
   }
 
   export interface RawTransactionToSign
@@ -429,82 +168,5 @@ export namespace CKBComponents {
     cellsCount: string;
   }
 
-  export interface BlockEconomicState {
-    finalizedAt: string;
-    issuance: {
-      primary: string;
-      secondary: string;
-    };
-    minerReward: {
-      committed: string;
-      primary: string;
-      proposal: string;
-      secondary: string;
-    };
-    txsFee: string;
-  }
-
-  export interface SyncState {
-    bestKnownBlockNumber: string;
-    bestKnownBlockTimestamp: string;
-    fastTime: string;
-    ibd: boolean;
-    inflightBlocksCount: string;
-    lowTime: string;
-    normalTime: string;
-    orphanBlocksCount: string;
-  }
-
-  export interface TransactionProof {
-    blockHash: Hash;
-    proof: {
-      indices: number[];
-      lemmas: Hash[];
-    };
-    witnessesRoot: Hash;
-  }
-
   export type TxPoolIds = Record<"pending" | "proposed", Array<Hash256>>;
-
-  export interface TxVerbosity {
-    cycles: Cycles;
-    size: Size;
-    fee: Capacity;
-    ancestorsSize: Size;
-    ancestorsCycles: Cycles;
-    ancestorsCount: Count;
-  }
-
-  export type TxPoolVerbosity = Record<
-    "pending" | "proposed",
-    Record<Hash256, TxVerbosity>
-  >;
-
-  export type RawTxPool = TxPoolIds | TxPoolVerbosity;
-
-  export interface Consensus {
-    id: string;
-    genesisHash: Hash256;
-    hardforkFeatures: Array<{ rfc: string; epochNumber: string | undefined }>;
-    daoTypeHash: Hash256 | undefined;
-    secp256k1Blake160SighashAllTypeHash: Hash256 | undefined;
-    secp256k1Blake160MultisigAllTypeHash: Hash256 | undefined;
-    initialPrimaryEpochReward: Capacity;
-    secondaryEpochReward: Capacity;
-    maxUnclesNum: string;
-    orphanRateTarget: RationalU256;
-    epochDurationTarget: string;
-    txProposalWindow: ProposalWindow;
-    proposerRewardRatio: RationalU256;
-    cellbaseMaturity: EpochNumberWithFraction;
-    medianTimeBlockCount: Count;
-    maxBlockCycles: Cycles;
-    maxBlockBytes: string;
-    blockVersion: Version;
-    txVersion: Version;
-    typeIdCodeHash: Hash256;
-    maxBlockProposalsLimit: string;
-    primaryEpochRewardHalvingInterval: string;
-    permanentDifficultyInDummy: boolean;
-  }
 }

--- a/packages/rpc/src/types/rpc.ts
+++ b/packages/rpc/src/types/rpc.ts
@@ -51,7 +51,7 @@ export namespace RPC {
   }
 
   export interface CellInput {
-    previous_output: OutPoint | undefined;
+    previous_output: OutPoint;
     since: Since;
   }
 
@@ -64,7 +64,7 @@ export namespace RPC {
   export type Cell = CellOutput;
 
   export interface LiveCell {
-    data?: {
+    data: {
       content: Hash;
       hash: Hash256;
     };
@@ -72,7 +72,7 @@ export namespace RPC {
   }
 
   export interface CellDep {
-    out_point: OutPoint | undefined;
+    out_point: OutPoint;
     dep_type: DepType;
   }
 
@@ -80,7 +80,7 @@ export namespace RPC {
     block_hash: Hash256;
     capacity: Capacity;
     lock: Script;
-    out_point: OutPoint | undefined;
+    out_point: OutPoint;
     cellbase: boolean;
     output_data_len: string;
   }
@@ -293,7 +293,7 @@ export namespace RPC {
   export interface TransactionProof {
     block_hash: Hash;
     proof: {
-      indices: number[];
+      indices: string[];
       lemmas: Hash[];
     };
     witnesses_root: Hash;

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/testkit",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "Test toolkit for CKB",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
   "license": "MIT",
@@ -18,9 +18,9 @@
     "src"
   ],
   "dependencies": {
-    "@ckb-lumos/base": "0.18.0",
-    "@ckb-lumos/bi": "0.18.0",
-    "@ckb-lumos/codec": "0.18.0",
+    "@ckb-lumos/base": "^0.19.0-alpha.0",
+    "@ckb-lumos/bi": "^0.19.0-alpha.0",
+    "@ckb-lumos/codec": "^0.19.0-alpha.0",
     "@types/body-parser": "^1.19.1",
     "@types/express": "^4.17.13",
     "body-parser": "^1.19.0",

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/toolkit",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "JavaScript toolkits used to build dapps for Nervos CKB",
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/packages/transaction-manager/package.json
+++ b/packages/transaction-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckb-lumos/transaction-manager",
-  "version": "0.18.0",
+  "version": "0.19.0-alpha.0",
   "description": "Pending Transaction Manager for lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
   "homepage": "https://github.com/nervosnetwork/lumos#readme",
@@ -31,10 +31,10 @@
     "url": "https://github.com/nervosnetwork/lumos/issues"
   },
   "dependencies": {
-    "@ckb-lumos/rpc": "0.18.0",
-    "@ckb-lumos/base": "0.18.0",
-    "@ckb-lumos/ckb-indexer": "0.18.0",
-    "@ckb-lumos/toolkit": "0.18.0",
+    "@ckb-lumos/base": "^0.19.0-alpha.0",
+    "@ckb-lumos/ckb-indexer": "^0.19.0-alpha.0",
+    "@ckb-lumos/rpc": "^0.19.0-alpha.0",
+    "@ckb-lumos/toolkit": "^0.19.0-alpha.0",
     "immutable": "^4.0.0-rc.12"
   },
   "publishConfig": {

--- a/website/docs/migrations/migrate-to-v0.19.md
+++ b/website/docs/migrations/migrate-to-v0.19.md
@@ -22,7 +22,7 @@ Running the codemod will:
 2. show warnings for deprecated functions.
 
 ```sh
-curl -s https://gist.githubusercontent.com/zhangyouxin/e5ddf9b966f611173a01d6c98715c931/raw/30606c12756a866437a390add8dc5f5df47c9c36/codemod.js \
+curl -s https://gist.githubusercontent.com/zhangyouxin/e5ddf9b966f611173a01d6c98715c931/raw \
 | xargs -0 -I{} node -e {} "your-source-dir/**/*.js"
 ```
 
@@ -56,12 +56,13 @@ Rewrite Serialization and DeSerialization codes.
 +    witness = bytes.hexify(blockchain.WitnessArgs.pack(newWitnessArgs))
 ```
 
-### Step 3 - Utility Functions in `@ckb-lumos/base/utils`
+### Step 3 - Misc
 
 Some other changes you should take care of.
 
 - removed `digestReader` of `CKBHasher` class in `@ckb-lumos/base/utils`
 - return type of `ckbhash` function has changed to `HexString`
+- `blockchain` exposed in `@ckb-lumos/codec` has been moved to `@ckb-lumos/base`
 
 ```diff
   const hasher = new CKBHasher()
@@ -71,6 +72,9 @@ Some other changes you should take care of.
   // if you would like to manipulate ArrayBuffer
 + import { bytes } from "@ckb-lumos/codec"
 + const messageBytes = bytes.bytify(message)
+  // blockchain has been moved
+- import { blockchain } from "@ckb-lumos/codec"
++ import { blockchain } from "@ckb-lumos/base"
 ```
 
 After doing the 3 steps, you have done migrating to v0.19.


### PR DESCRIPTION
This pr has:

- fixed export error of `@ckb-lumos/base`
- use types from `@ckb-lumos/base` in '@ckb-lumos/rpc'
- removed useless test cases
- change SearchKey of `indexer-rpc` methods params to camelCase & added test cases
- updated migration guide & codemod.js