### PR TITLE
feat: supported minimalScriptCapacity

### DIFF
--- a/packages/common-scripts/src/dao.ts
+++ b/packages/common-scripts/src/dao.ts
@@ -605,7 +605,7 @@ function _addDaoCellDep(
   });
 }
 
-function extractDaoDataCompatible(dao: PackedDao): {
+export function extractDaoDataCompatible(dao: PackedDao): {
   [key: string]: BI;
 } {
   if (!/^(0x)?([0-9a-fA-F]){64}$/.test(dao)) {

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -30,6 +30,31 @@ export interface Options {
 
 const BECH32_LIMIT = 1023;
 
+export function minimalScriptCapacity(
+  script: Script,
+  { validate = true }: { validate?: boolean } = {}
+): bigint {
+  const result = minimalScriptCapacityCompatible(script, { validate });
+  return BigInt(result.toString());
+}
+
+export function minimalScriptCapacityCompatible(
+  script: Script,
+  { validate = true }: { validate?: boolean } = {}
+): BI {
+  if (validate) {
+    validators.ValidateScript(script);
+  }
+
+  let bytes = 0;
+  bytes += bytify(script.codeHash).length;
+  bytes += bytify(script.args).length;
+  // hash_type field
+  bytes += 1;
+
+  return BI.from(bytes).mul(100000000);
+}
+
 export function minimalCellCapacity(
   fullCell: Cell,
   { validate = true }: { validate?: boolean } = {}

--- a/packages/helpers/tests/minimal_cell_capacity-bigint.test.ts
+++ b/packages/helpers/tests/minimal_cell_capacity-bigint.test.ts
@@ -1,6 +1,6 @@
 import test from "ava";
 import { Cell } from "@ckb-lumos/base";
-import { minimalCellCapacity } from "../src";
+import { minimalCellCapacity, minimalScriptCapacity } from "../src";
 
 const normalCell: Cell = {
   cellOutput: {
@@ -52,5 +52,27 @@ test("BigInt:cell with type and data, validate true", (t) => {
   const capacity = minimalCellCapacity(cellWithTypeAndData);
   const expectedCapacity = BigInt((61 + 33 + 2) * 10 ** 8);
 
+  t.true(capacity === expectedCapacity);
+});
+
+test("BigInt:no args script capacity", (t) => {
+  const capacity = minimalScriptCapacity({
+    args: "0x",
+    codeHash:
+      "0x82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e",
+    hashType: "type",
+  });
+  const expectedCapacity = BigInt(33 * 10 ** 8);
+  t.true(capacity === expectedCapacity);
+});
+
+test("BigInt:normal script, validate true", (t) => {
+  const capacity = minimalScriptCapacity({
+    args: "0x36c329ed630d6ce750712a477543672adab57f4c",
+    codeHash:
+      "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+    hashType: "type",
+  });
+  const expectedCapacity = BigInt(53 * 10 ** 8);
   t.true(capacity === expectedCapacity);
 });

--- a/packages/helpers/tests/minimal_cell_capacity.test.ts
+++ b/packages/helpers/tests/minimal_cell_capacity.test.ts
@@ -1,6 +1,10 @@
 import test from "ava";
 import { Cell } from "@ckb-lumos/base";
-import { minimalCellCapacity, minimalCellCapacityCompatible } from "../src";
+import {
+  minimalCellCapacity,
+  minimalCellCapacityCompatible,
+  minimalScriptCapacityCompatible,
+} from "../src";
 import { BI } from "@ckb-lumos/bi";
 
 const normalCell: Cell = {
@@ -82,4 +86,37 @@ test("cell with type and data, validate true", (t) => {
   const capacity = minimalCellCapacityCompatible(cellWithTypeAndData);
   const expectedCapacity = BI.from(61 + 33 + 2).mul(BI.from(10).pow(8));
   t.true(capacity.toString() === expectedCapacity.toString());
+});
+
+test("no args script capacity", (t) => {
+  const capacity = minimalScriptCapacityCompatible({
+    args: "0x",
+    codeHash:
+      "0x82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e",
+    hashType: "type",
+  });
+  const expectedCapacity = BI.from(33).mul(BI.from(10).pow(8));
+  t.true(capacity.toString() === expectedCapacity.toString());
+});
+
+test("normal script, validate true", (t) => {
+  const capacity = minimalScriptCapacityCompatible({
+    args: "0x36c329ed630d6ce750712a477543672adab57f4c",
+    codeHash:
+      "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+    hashType: "type",
+  });
+  const expectedCapacity = BI.from(53).mul(BI.from(10).pow(8));
+  t.true(capacity.toString() === expectedCapacity.toString());
+});
+
+test("invalid script, validate failed", (t) => {
+  t.throws(() => {
+    minimalScriptCapacityCompatible({
+      args: "0x36c329ed630d6ce750712a477543672adab57f4c",
+      codeHash:
+        "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+      hashType: "invalid",
+    } as any);
+  });
 });


### PR DESCRIPTION
Add functions that are missing compared to `ckb-sdk-utils`
It was pull request once before, maybe it was losted during the upgrade, reopen it: https://github.com/nervosnetwork/lumos/pull/372

```ts
declare function minimalScriptCapacity(script: Script): bigint;
declare function minimalScriptCapacityCompatible(script: Script): BI;
```