### PR TITLE
fix(common-scripts): avoid run vm1 code in vm0 when deploy

### DIFF
--- a/packages/common-scripts/src/deploy.ts
+++ b/packages/common-scripts/src/deploy.ts
@@ -346,7 +346,7 @@ interface ScriptConfig {
   // if hashType is data, codeHash is ckbHash(data)
   CODE_HASH: string;
 
-  HASH_TYPE: "type" | "data";
+  HASH_TYPE: "type" | "data1";
 
   TX_HASH: string;
   // the deploy cell can be found at index of tx's outputs
@@ -374,7 +374,7 @@ function getScriptConfigByDataHash(
   const txHash = calculateTxHash(txSkeleton);
   const scriptConfig: ScriptConfig = {
     CODE_HASH: codeHash,
-    HASH_TYPE: "data",
+    HASH_TYPE: "data1",
     TX_HASH: txHash,
     INDEX: "0x0",
     DEP_TYPE: "code",


### PR DESCRIPTION
ckb-vm has upgraded and the vm1 is compatible with vm0, but vm0 is not full supported vm1, we should avoid running vm1's code in vm0