### PR TITLE
chore: replace github repo link to ckb-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # lumos
 
-![build](https://github.com/nervosnetwork/lumos/actions/workflows/github-ci.yaml/badge.svg)
-[![codecov](https://codecov.io/gh/nervosnetwork/lumos/branch/develop/graph/badge.svg?token=6WJJOOMD2F)](https://codecov.io/gh/nervosnetwork/lumos)
-![license](https://img.shields.io/github/license/nervosnetwork/lumos)
+![build](https://github.com/ckb-js/lumos/actions/workflows/github-ci.yaml/badge.svg)
+[![codecov](https://codecov.io/gh/ckb-js/lumos/branch/develop/graph/badge.svg?token=6WJJOOMD2F)](https://codecov.io/gh/ckb-js/lumos)
+![license](https://img.shields.io/github/license/ckb-js/lumos)
 ![Lumos](./assets/lumos.jpg)
 
 > Lumos is still under active development and considered to be a work in progress.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@
 ### Build lumos
 
 ```sh
-git clone https://github.com/nervosnetwork/lumos.git
+git clone https://github.com/ckb-js/lumos.git
 cd lumos
 yarn
 yarn build
@@ -23,7 +23,7 @@ yarn ts-node examples/config-manager.ts
 Using [GitHubBox.com](https://codesandbox.io/docs/importing#using-githubboxcom), you can preview and interact with example code online through codesandbox.
 
 For example:  
-Change the GitHub URL: https://github.com/nervosnetwork/lumos/tree/develop/examples/omni-lock-metamask  
-To: https://githubbox.com/nervosnetwork/lumos/tree/develop/examples/omni-lock-metamask
+Change the GitHub URL: https://github.com/ckb-js/lumos/tree/develop/examples/omni-lock-metamask  
+To: https://githubbox.com/ckb-js/lumos/tree/develop/examples/omni-lock-metamask
 
-Note that due to the incompatibility of namiwallet and iframe, you need to open the result in a new window while opening [cardano-lock-namiwallet](https://github.com/nervosnetwork/lumos/tree/develop/examples/cardano-lock-namiwallet) with codesandbox.
+Note that due to the incompatibility of namiwallet and iframe, you need to open the result in a new window while opening [cardano-lock-namiwallet](https://github.com/ckb-js/lumos/tree/develop/examples/cardano-lock-namiwallet) with codesandbox.

--- a/examples/cardano-lock-namiwallet/README.md
+++ b/examples/cardano-lock-namiwallet/README.md
@@ -24,8 +24,8 @@ The cardano lock is compiled from this [commit](https://github.com/nervosnetwork
 
 Using [GitHubBox.com](https://codesandbox.io/docs/importing#using-githubboxcom), you can preview and interact with example code online through codesandbox.
 
-Change the GitHub URL: https://github.com/nervosnetwork/lumos/tree/develop/examples/cardano-lock-namiwallet  
-To: https://githubbox.com/nervosnetwork/lumos/tree/develop/examples/cardano-lock-namiwallet
+Change the GitHub URL: https://github.com/ckb-js/lumos/tree/develop/examples/cardano-lock-namiwallet  
+To: https://githubbox.com/ckb-js/lumos/tree/develop/examples/cardano-lock-namiwallet
 
 Note that due to the incompatibility of namiwallet and iframe, you need to open the result in a new window:  
 ![codesandbox](./codesandbox.png)

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.0-alpha.2",
   "description": "Base data structures and utilities used in lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "index.d.ts",
@@ -20,7 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "scripts": {
     "build": "npm run build:types && npm run build:js",
@@ -37,7 +37,7 @@
     "rollup": "^1.32.0"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "ava": {
     "extensions": [

--- a/packages/bi/package.json
+++ b/packages/bi/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.0-alpha.1",
   "description": "Bigint support in lumos",
   "author": "",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "scripts": {
     "fmt": "prettier --write \"{src,tests,examples}/**/*.ts\" package.json",
@@ -37,7 +37,7 @@
     "release": "npm publish"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "ava": {
     "extensions": [

--- a/packages/ckb-indexer/README.md
+++ b/packages/ckb-indexer/README.md
@@ -154,7 +154,7 @@ for await (const cell of cellCollector.collect()) {
 }
 ```
 
-Fine grained query for cells can be achieved by using [ScriptWrapper](https://github.com/nervosnetwork/lumos/blob/cd418d258085d3cb6ab47eeaf5347073acf5422e/packages/base/index.d.ts#L123), with customized options like `argsLen`:
+Fine grained query for cells can be achieved by using [ScriptWrapper](https://github.com/ckb-js/lumos/blob/cd418d258085d3cb6ab47eeaf5347073acf5422e/packages/base/index.d.ts#L123), with customized options like `argsLen`:
 
 ```jsx
 cellCollector = new CellCollector(indexer, {
@@ -338,7 +338,7 @@ for await (const tx of txCollector.collect()) {
 }
 ```
 
-Fine grained query for transactions can be achieved by using [ScriptWrapper](https://github.com/nervosnetwork/lumos/blob/cd418d258085d3cb6ab47eeaf5347073acf5422e/packages/base/index.d.ts#L123), with customized options like `ioType`, `argsLen`:
+Fine grained query for transactions can be achieved by using [ScriptWrapper](https://github.com/ckb-js/lumos/blob/cd418d258085d3cb6ab47eeaf5347073acf5422e/packages/base/index.d.ts#L123), with customized options like `ioType`, `argsLen`:
 
 ```jsx
 txCollector = new TransactionCollector(indexer, {
@@ -443,4 +443,4 @@ medianTimeEmitter.on("changed", (medianTime) => {
 
 ## **Migration**
 
-If you want to migrate native indexer to ckb-indexer, please check more detail in our [migration docs](https://github.com/nervosnetwork/lumos/blob/develop/packages/ckb-indexer/mirgation.md)
+If you want to migrate native indexer to ckb-indexer, please check more detail in our [migration docs](https://github.com/ckb-js/lumos/blob/develop/packages/ckb-indexer/mirgation.md)

--- a/packages/ckb-indexer/package.json
+++ b/packages/ckb-indexer/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.0-alpha.2",
   "description": "CKB Indexer",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "files": [
     "lib",
@@ -50,7 +50,7 @@
     "release": "npm publish"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "ava": {
     "extensions": [

--- a/packages/codec/package.json
+++ b/packages/codec/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.0-alpha.1",
   "description": "Make your own molecule binding in JavaScript(TypeScript)",
   "author": "",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -16,7 +16,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "scripts": {
     "fmt": "prettier --write \"{src,tests,examples}/**/*.ts\" package.json",
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "ava": {
     "extensions": [

--- a/packages/common-scripts/README.md
+++ b/packages/common-scripts/README.md
@@ -211,4 +211,4 @@ const upgradeOptions = {
 let upgradeTxSkeleton = await generateUpgradeTypeIdDataTx(upgradeOptions);
 ```
 
-Check [omni lock example](https://github.com/nervosnetwork/lumos/blob/develop/examples/omni-lock-metamask/lib.ts) and [pw lock example](https://github.com/nervosnetwork/lumos/blob/develop/examples/pw-lock-metamask/lib.ts) for how to use `p2pkh` script.
+Check [omni lock example](https://github.com/ckb-js/lumos/blob/develop/examples/omni-lock-metamask/lib.ts) and [pw lock example](https://github.com/ckb-js/lumos/blob/develop/examples/pw-lock-metamask/lib.ts) for how to use `p2pkh` script.

--- a/packages/common-scripts/package.json
+++ b/packages/common-scripts/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.0-alpha.2",
   "description": "Common script support in lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "scripts": {
     "fmt": "prettier --write \"{src,tests,examples}/**/*.ts\" package.json",
@@ -44,7 +44,7 @@
     "release": "npm publish"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "ava": {
     "extensions": [

--- a/packages/config-manager/package.json
+++ b/packages/config-manager/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.0-alpha.2",
   "description": "Config manager for lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib",
   "engines": {
@@ -19,7 +19,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "scripts": {
     "fmt": "prettier --write \"{src,tests}/**/*.ts\" package.json",
@@ -33,7 +33,7 @@
     "release": "npm publish"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "dependencies": {
     "@ckb-lumos/base": "^0.19.0-alpha.2",

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -4,7 +4,7 @@
   "version": "0.19.0-alpha.2",
   "description": "ckb-standard-debugger wrapper for lumos, check tx without launching a full node",
   "author": "",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -42,7 +42,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "scripts": {
     "fmt": "prettier --write \"{src,tests,examples}/**/*.ts\" package.json",
@@ -56,7 +56,7 @@
     "release": "npm publish"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "ava": {
     "extensions": [

--- a/packages/experiment-tx-assembler/package.json
+++ b/packages/experiment-tx-assembler/package.json
@@ -2,7 +2,7 @@
   "name": "@ckb-lumos/experiment-tx-assembler",
   "version": "0.19.0-alpha.2",
   "description": "",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "scripts": {
     "fmt": "prettier --write \"{src,tests,examples}/**/*.ts\" package.json",
@@ -42,7 +42,7 @@
     "release": "npm publish"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "ava": {
     "extensions": [

--- a/packages/hd-cache/package.json
+++ b/packages/hd-cache/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.0-alpha.2",
   "description": "HD wallet cache in lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -29,7 +29,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "scripts": {
     "fmt": "prettier --write \"{src,tests}/**/*.ts\" package.json",
@@ -43,7 +43,7 @@
     "release": "npm publish"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "ava": {
     "extensions": [

--- a/packages/hd/package.json
+++ b/packages/hd/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.0-alpha.2",
   "description": "HD wallet manager in lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "scripts": {
     "fmt": "prettier --write \"{src,tests}/**/*.ts\" package.json",
@@ -42,7 +42,7 @@
     "release": "npm publish"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "ava": {
     "extensions": [

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.0-alpha.2",
   "description": "Helper functions for working with CKB",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -20,7 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "scripts": {
     "fmt": "prettier --write \"{src,tests}/**/*.ts\" package.json",
@@ -34,7 +34,7 @@
     "release": "npm publish"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "dependencies": {
     "@ckb-lumos/base": "^0.19.0-alpha.2",

--- a/packages/lumos/package.json
+++ b/packages/lumos/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.0-alpha.2",
   "description": "A root package for Lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "browser": "lib/lumos.min.js",
@@ -20,7 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "scripts": {
     "fmt": "prettier --write \"{src,tests}/**/*.ts\" package.json",
@@ -34,7 +34,7 @@
     "release": "npm publish"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "dependencies": {
     "@ckb-lumos/base": "^0.19.0-alpha.2",

--- a/packages/rpc/CHANGELOG.md
+++ b/packages/rpc/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [0.19.0-alpha.2](https://github.com/nervosnetwork/lumos/compare/v0.19.0-alpha.1...v0.19.0-alpha.2) (2022-09-04)
+# [0.19.0-alpha.2](https://github.com/ckb-js/lumos/compare/v0.19.0-alpha.1...v0.19.0-alpha.2) (2022-09-04)
 
 **Note:** Version bump only for package @ckb-lumos/rpc
 
@@ -11,15 +11,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.19.0-alpha.1](https://github.com/nervosnetwork/lumos/compare/v0.18.0...v0.19.0-alpha.1) (2022-08-17)
+# [0.19.0-alpha.1](https://github.com/ckb-js/lumos/compare/v0.18.0...v0.19.0-alpha.1) (2022-08-17)
 
 
 ### Bug Fixes
 
-* incompatible types in indexer and rpc ([#385](https://github.com/nervosnetwork/lumos/issues/385)) ([b8e4d10](https://github.com/nervosnetwork/lumos/commit/b8e4d108cf41643989b329368376462e70abdeb3))
+* incompatible types in indexer and rpc ([#385](https://github.com/ckb-js/lumos/issues/385)) ([b8e4d10](https://github.com/ckb-js/lumos/commit/b8e4d108cf41643989b329368376462e70abdeb3))
 
 
-* refactor!: camelize exposed APIs (#378) ([7c17f90](https://github.com/nervosnetwork/lumos/commit/7c17f901257b15934339022730db05c6912914f5)), closes [#378](https://github.com/nervosnetwork/lumos/issues/378)
+* refactor!: camelize exposed APIs (#378) ([7c17f90](https://github.com/ckb-js/lumos/commit/7c17f901257b15934339022730db05c6912914f5)), closes [#378](https://github.com/ckb-js/lumos/issues/378)
 
 
 ### BREAKING CHANGES
@@ -30,10 +30,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-# [0.19.0-alpha.0](https://github.com/nervosnetwork/lumos/compare/v0.18.0...v0.19.0-alpha.0) (2022-08-11)
+# [0.19.0-alpha.0](https://github.com/ckb-js/lumos/compare/v0.18.0...v0.19.0-alpha.0) (2022-08-11)
 
 
-* refactor!: camelize exposed APIs (#378) ([7c17f90](https://github.com/nervosnetwork/lumos/commit/7c17f901257b15934339022730db05c6912914f5)), closes [#378](https://github.com/nervosnetwork/lumos/issues/378)
+* refactor!: camelize exposed APIs (#378) ([7c17f90](https://github.com/ckb-js/lumos/commit/7c17f901257b15934339022730db05c6912914f5)), closes [#378](https://github.com/ckb-js/lumos/issues/378)
 
 
 ### BREAKING CHANGES

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -2,7 +2,7 @@
   "name": "@ckb-lumos/rpc",
   "version": "0.19.0-alpha.2",
   "description": "RPC module for CKB",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "engines": {
@@ -20,10 +20,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "scripts": {
     "doc": "../../node_modules/.bin/typedoc --out docs --mode modules --includeDeclarations --excludeExternals --ignoreCompilerErrors --theme default",

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -2,7 +2,7 @@
   "name": "@ckb-lumos/testkit",
   "version": "0.19.0-alpha.2",
   "description": "Test toolkit for CKB",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "scripts": {
     "start": "ts-node example/mock-ckb-node.ts",
@@ -46,7 +46,7 @@
     "build:js": "babel --root-mode upward src --out-dir lib --extensions .ts -s"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "ava": {
     "extensions": [

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "files": [
     "types",

--- a/packages/transaction-manager/package.json
+++ b/packages/transaction-manager/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.0-alpha.2",
   "description": "Pending Transaction Manager for lumos",
   "author": "Xuejie Xiao <xxuejie@gmail.com>",
-  "homepage": "https://github.com/nervosnetwork/lumos#readme",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "index.d.ts",
@@ -20,7 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/lumos.git"
+    "url": "git+https://github.com/ckb-js/lumos.git"
   },
   "scripts": {
     "fmt": "prettier --write \"{lib,tests}/**/*.js\" index.d.ts package.json",
@@ -28,7 +28,7 @@
     "test": "ava **/*.test.js"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/lumos/issues"
+    "url": "https://github.com/ckb-js/lumos/issues"
   },
   "dependencies": {
     "@ckb-lumos/base": "^0.19.0-alpha.2",

--- a/style.md
+++ b/style.md
@@ -15,7 +15,7 @@ This is not something that is as complete as a [formal Style Guide](https://goog
 * All Rust code should be compiled without warnings by the latest stable version of Rust.
 * All Rust code should be formatted via the latest stable version of cargofmt.
 * All Rust code should be checked by the latest stable version of clippy.
-* As mentioned above, all components using Rust code shall provide pre-built binaries. See [indexer](https://github.com/nervosnetwork/lumos/tree/master/packages/indexer) for an example.
+* As mentioned above, all components using Rust code shall provide pre-built binaries. See [indexer](https://github.com/ckb-js/lumos/tree/develop/packages/ckb-indexer) for an example.
 
 ## JavaScript/TypeScript Specific Part
 

--- a/website/docs/01-run-lumos-in-the-browser.md
+++ b/website/docs/01-run-lumos-in-the-browser.md
@@ -35,7 +35,7 @@ async function main(): Promise<BI> {
 main();
 ```
 
-please refer to [ckb-indexer-collector example](https://github.com/nervosnetwork/lumos/blob/develop/examples/ckb-indexer-collector.ts) for a complete example.
+please refer to [ckb-indexer-collector example](https://github.com/ckb-js/lumos/blob/develop/examples/ckb-indexer-collector.ts) for a complete example.
 
 ### ckb-indexer
 
@@ -48,9 +48,9 @@ const indexUri = "https://testnet.ckb.dev/indexer";
 const indexer = new Indexer(indexUri, nodeUri);
 ```
 
-For a detailed tutorial, please refer to the [ckb-indexer User Guide](https://github.com/nervosnetwork/lumos/tree/develop/packages/ckb-indexer).
+For a detailed tutorial, please refer to the [ckb-indexer User Guide](https://github.com/ckb-js/lumos/tree/develop/packages/ckb-indexer).
 
-To migrate from `@ckb-lumos/indexer` to `@ckb-lumos/ckb-indexer`, please refer to the [migration documentation](https://github.com/nervosnetwork/lumos/blob/develop/packages/ckb-indexer/mirgation.md).
+To migrate from `@ckb-lumos/indexer` to `@ckb-lumos/ckb-indexer`, please refer to the [migration documentation](https://github.com/ckb-js/lumos/blob/develop/packages/ckb-indexer/mirgation.md).
 
 ### root package
 
@@ -72,7 +72,7 @@ const lock: Script = helpers.parseAddress(address);
 
 ### BI big number library
 
-In order to facilitate the calculation of large numbers, we provide the [large number library BI](https://github.com/nervosnetwork/lumos/tree/develop/packages/bi). You can convert strings, numbers, etc. to and from BI and perform some common operations.
+In order to facilitate the calculation of large numbers, we provide the [large number library BI](https://github.com/ckb-js/lumos/tree/develop/packages/bi). You can convert strings, numbers, etc. to and from BI and perform some common operations.
 
 ```jsx
 import { BI } from "@ckb-lumos/bi";
@@ -80,7 +80,7 @@ import { BI } from "@ckb-lumos/bi";
 BI.from(1).add(1);
 ```
 
-For more use of the API, please refer to [BI Test Cases](https://github.com/nervosnetwork/lumos/blob/develop/packages/bi/tests/index.test.ts).
+For more use of the API, please refer to [BI Test Cases](https://github.com/ckb-js/lumos/blob/develop/packages/bi/tests/index.test.ts).
 
 ### More Updates
 
@@ -90,11 +90,11 @@ For more use of the API, please refer to [BI Test Cases](https://github.com/nerv
 
 2. Conversion of new addresses
 
-   Lumos also supports ckb2021 upgraded [address](https://github.com/nervosnetwork/rfcs/pull/239/files), adding methods such as `encodeToAddress`. Refer to this [PR](https://github.com/nervosnetwork/lumos/pull/205) for more.
+   Lumos also supports ckb2021 upgraded [address](https://github.com/nervosnetwork/rfcs/pull/239/files), adding methods such as `encodeToAddress`. Refer to this [PR](https://github.com/ckb-js/lumos/pull/205) for more.
 
 3. Example code additions
 
-   Added `secp256k1-transfer`, `secp256k1-multisig-transfer`, `pw-lock-metamask`, `omni-lock-metamask` and other sample code, please refer to [lumos/example](https://[github.com/nervosnetwork/lumos/tree/develop/examples)
+   Added `secp256k1-transfer`, `secp256k1-multisig-transfer`, `pw-lock-metamask`, `omni-lock-metamask` and other sample code, please refer to [lumos/example](https://[github.com/ckb-js/lumos/tree/develop/examples)
 
 4. Online tools
 
@@ -104,7 +104,7 @@ For more use of the API, please refer to [BI Test Cases](https://github.com/nerv
 
    We used codesandbox and `@ckb-lumos/lumos` to build the [playground](https://codesandbox.io/s/objective-cloud-282i4?file=/src/index.js) where you can quickly try out the features of lumos.
 
-6. A contract deployment generator is provided in lumos to facilitate the deployment of contracts, visit the link [🔗](https://github.com/nervosnetwork/lumos/tree/develop/packages/common-scripts#usage)
+6. A contract deployment generator is provided in lumos to facilitate the deployment of contracts, visit the link [🔗](https://github.com/ckb-js/lumos/tree/develop/packages/common-scripts#usage)
 
 ### Follow-up plan
 

--- a/website/docs/migrations/migrate-form-ckb-sdk-utils.md
+++ b/website/docs/migrations/migrate-form-ckb-sdk-utils.md
@@ -9,7 +9,7 @@ with `@ckb-lumos/codec`.
 ## @lumos/codec
 
 @lumos/codec provides a set of functions to pack(encode) and unpack(decode) data.
-related link: https://github.com/nervosnetwork/lumos/blob/develop/packages/codec
+related link: https://github.com/ckb-js/lumos/blob/develop/packages/codec
 
 ## Migration list
 

--- a/website/docs/migrations/migrate-from-ckb-sdk-core.md
+++ b/website/docs/migrations/migrate-from-ckb-sdk-core.md
@@ -8,7 +8,7 @@ If you are using any function that is not on this list, please refer to the `lum
 
 reference:
 
-- [lumos](https://github.com/nervosnetwork/lumos)
+- [lumos](https://github.com/ckb-js/lumos)
 - [ckb-sdk-core](https://github.com/nervosnetwork/ckb-sdk-js)
 
 ## Transaction migration example list

--- a/website/docs/migrations/migrate-to-v0.19.md
+++ b/website/docs/migrations/migrate-to-v0.19.md
@@ -105,7 +105,7 @@ Check the warnings in the console of step 1,  deprecated functions work for now 
 
 ## A Real World Migration Example
 
-Here is a simple example of how we could migrate [secp256k1-transfer](https://github.com/nervosnetwork/lumos/blob/1669bf527c/examples/secp256k1-transfer/lib.ts) to the new version.
+Here is a simple example of how we could migrate [secp256k1-transfer](https://github.com/ckb-js/lumos/blob/1669bf527c/examples/secp256k1-transfer/lib.ts) to the new version.
 
 ```diff
 ...

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -42,7 +42,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            "https://github.com/nervosnetwork/lumos/tree/develop/website",
+            "https://github.com/ckb-js/lumos/tree/develop/website",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
@@ -91,7 +91,7 @@ const config = {
             ]
           },
           {
-            href: "https://github.com/nervosnetwork/lumos",
+            href: "https://github.com/ckb-js/lumos",
             label: "GitHub",
             position: "right",
           },


### PR DESCRIPTION
# Description
- [x] Replace the GitHub repo URL from nervosnetwork/lumos to ckb-js/lumos https://github.com/nervosnetwork/lumos/issues/401

## Type of change

- [x] other

# How Has This Been Tested?

- [x] click all changed links after transfer

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules