### PR TITLE
feat(helpers): parse address via known config key

### DIFF
--- a/packages/helpers/tests/encode_address.test.ts
+++ b/packages/helpers/tests/encode_address.test.ts
@@ -1,5 +1,5 @@
 import test from "ava";
-import { encodeToAddress } from "../src";
+import { encodeToAddress, encodeToConfigAddress } from "../src";
 import { predefined } from "@ckb-lumos/config-manager";
 import { Script } from "@ckb-lumos/base";
 
@@ -37,4 +37,25 @@ test("encode to full address, data1", (t) => {
     testnetAddress,
     "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq4nnw7qkdnnclfkg59uzn8umtfd2kwxceqkkxdwn"
   );
+});
+
+test("encode to address via config key", (t) => {
+  const testnetAddress = encodeToConfigAddress(
+    "0x159890a7cacb44a95bef0743064433d763de229c",
+    "SECP256K1_BLAKE160",
+    { config: AGGRON }
+  );
+
+  t.is(
+    testnetAddress,
+    "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqg4nzg20jktgj54hmc8gvrygv7hv00z98qklce9w"
+  );
+
+  t.throws(() => {
+    encodeToConfigAddress(
+      "0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64",
+      "UNKNOWN_LOCK" as any,
+      { config: AGGRON }
+    );
+  });
 });


### PR DESCRIPTION
# Description

A convenient typescript-friendly function for parsing a lock to an address via `CONFIG.SCRIPT.KEY`, BTW, this PR marks some `generateXAddress` as deprecated

```ts

encodeToConfigAddress('0xpubkey hash', 'SECP256K1_BLAKE160', { config: AGGRON });

```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Website
- [ ] Example
- [ ] Other

# How Has This Been Tested?

<!--  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [x] unit test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules