### PR TITLE
feat: support timeout in rpc

### DIFF
--- a/packages/rpc/__tests__/nock-test/rpc.test.js
+++ b/packages/rpc/__tests__/nock-test/rpc.test.js
@@ -1,0 +1,42 @@
+const nock = require("nock");
+const { RPC } = require("../../lib");
+
+const nodeUrl = "http://nock-rpc.com";
+
+describe("rpc", () => {
+  it("should throw time exceeded error", async () => {
+    nock(nodeUrl)
+      .post("/")
+      .delay(1000)
+      .reply(200, (uri, requestBody) => {
+        return {
+          jsonrpc: "2.0",
+          result:
+            "0x10639e0895502b5688a6be8cf69460d76541bfa4821629d86d62ba0aae3f9606",
+          id: requestBody.id,
+        };
+      });
+    const rpc = new RPC(nodeUrl, { timeout: 100 });
+    try {
+      await rpc.getBlockHash("0x01");
+    } catch (err) {
+      expect(err.message).toEqual("timeout of 100ms exceeded");
+    }
+  });
+  it("should call rpc successful", async () => {
+    nock(nodeUrl)
+      .post("/")
+      .delay(1000)
+      .reply(200, (uri, requestBody) => {
+        return {
+          jsonrpc: "2.0",
+          result:
+            "0x10639e0895502b5688a6be8cf69460d76541bfa4821629d86d62ba0aae3f9606",
+          id: requestBody.id,
+        };
+      });
+    const rpc = new RPC(nodeUrl, { timeout: 2000 });
+    const res =  await rpc.getBlockHash("0x01");
+    expect(res).toEqual('0x10639e0895502b5688a6be8cf69460d76541bfa4821629d86d62ba0aae3f9606')
+  });
+});

--- a/packages/rpc/example/README.md
+++ b/packages/rpc/example/README.md
@@ -1,0 +1,12 @@
+# Examples
+
+## Motivation
+
+This example shows how to configure rpc timeout. Follow the guide to run a mock RPC server and see how it works.
+
+## Usage
+
+```bash
+ts-node example/mockRpcServer.ts
+ts-node example/rpc.ts
+```

--- a/packages/rpc/example/mockRpcServer.ts
+++ b/packages/rpc/example/mockRpcServer.ts
@@ -1,0 +1,25 @@
+import express from 'express'
+
+const app = express();
+
+app.use(
+  express.urlencoded({
+    extended: true,
+  })
+);
+
+app.use(express.json());
+
+app.post('/', (req, res) => {
+  setTimeout(() => {
+    console.log(req.body);
+    res.send({
+      "jsonrpc": "2.0",
+      "result": "0x10639e0895502b5688a6be8cf69460d76541bfa4821629d86d62ba0aae3f9606",
+      "id": req.body.id
+    })
+  }, 3000)
+});
+
+
+app.listen(8080)

--- a/packages/rpc/example/rpc.ts
+++ b/packages/rpc/example/rpc.ts
@@ -1,0 +1,12 @@
+import { RPC } from '../src'
+
+const main = async () => {
+  const rpc = new RPC('http://localhost:8080', { timeout: 100 })
+  const d1 = Date.now()
+  console.log('before call', );
+  await rpc.getBlockHash('0x1')
+  const d2 = Date.now()
+  console.log('time:', d2-d1);
+}
+
+main()

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -44,6 +44,7 @@
     "tslib": "2.3.1"
   },
   "devDependencies": {
+    "express": "^4.18.1",
     "jest": "^28.1.3"
   }
 }

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -44,7 +44,9 @@
     "tslib": "2.3.1"
   },
   "devDependencies": {
+    "@types/nock": "^11.1.0",
     "express": "^4.18.1",
-    "jest": "^28.1.3"
+    "jest": "^28.1.3",
+    "nock": "^13.2.9"
   }
 }

--- a/packages/rpc/src/method.ts
+++ b/packages/rpc/src/method.ts
@@ -1,9 +1,11 @@
 import axios from "axios";
 import { IdNotMatchException, ResponseException } from "./exceptions";
 import { CKBComponents } from "./types/api";
+import { RPCConfig } from "./types/common";
 
 export class Method {
   #name: string;
+  #config: RPCConfig;
 
   get name(): string {
     return this.#name;
@@ -18,10 +20,16 @@ export class Method {
 
   #node: CKBComponents.Node;
 
-  constructor(node: CKBComponents.Node, options: CKBComponents.Method) {
+  constructor(
+    node: CKBComponents.Node,
+    options: CKBComponents.Method,
+    config: RPCConfig = { timeout: 30000 }
+  ) {
     this.#node = node;
     this.#options = options;
     this.#name = options.name;
+    this.#config = config;
+
     Object.defineProperty(this.call, "name", {
       value: options.name,
       configurable: false,
@@ -41,6 +49,7 @@ export class Method {
       url: this.#node.url,
       httpAgent: this.#node.httpAgent,
       httpsAgent: this.#node.httpsAgent,
+      timeout: this.#config.timeout,
     }).then((res) => {
       if (res.data.id !== payload.id) {
         throw new IdNotMatchException(payload.id, res.data.id);

--- a/packages/rpc/src/types/common.ts
+++ b/packages/rpc/src/types/common.ts
@@ -1,0 +1,3 @@
+export type RPCConfig = {
+  timeout: number;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3355,6 +3355,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
+"@types/nock@^11.1.0":
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/@types/nock/-/nock-11.1.0.tgz#0a8c1056a31ba32a959843abccf99626dd90a538"
+  integrity sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==
+  dependencies:
+    nock "*"
+
 "@types/node@*", "@types/node@>=12":
   version "18.6.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.1.tgz#828e4785ccca13f44e2fb6852ae0ef11e3e20ba5"
@@ -8254,7 +8261,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.7.0:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8812,6 +8819,16 @@ nise@^5.1.0:
     "@sinonjs/text-encoding" "^0.7.1"
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
+
+nock@*, nock@^13.2.9:
+  version "13.2.9"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.2.9.tgz#4faf6c28175d36044da4cfa68e33e5a15086ad4c"
+  integrity sha512-1+XfJNYF1cjGB+TKMWi29eZ0b82QOvQs2YoLNzbpWGqFMtRQHTa57osqdGj4FrFPgkO4D4AZinzUJR9VvW3QUA==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.21"
+    propagate "^2.0.0"
 
 node-addon-api@^2.0.0:
   version "2.0.2"
@@ -9741,6 +9758,11 @@ promzard@^0.3.0:
   integrity sha512-JZeYqd7UAcHCwI+sTOeUDYkvEU+1bQ7iE0UT1MgB/tERkAPkesW46MrpIySzODi+owTjZtiF8Ay5j9m60KmMBw==
   dependencies:
     read "1"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 proto-list@~1.2.1:
   version "1.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3787,7 +3787,12 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^2.0.0, ansi-regex@^5.0.1:
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
+
+ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -6010,7 +6015,7 @@ expect@^28.1.3:
     jest-message-util "^28.1.3"
     jest-util "^28.1.3"
 
-express@^4.17.1:
+express@^4.17.1, express@^4.18.1:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.1.tgz#7797de8b9c72c857b9cd0e14a5eea80666267caf"
   integrity sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==
@@ -6816,10 +6821,15 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-highlight.js@^10.0.0, highlight.js@^10.4.1, highlight.js@^9.15.6:
+highlight.js@^10.0.0:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
+
+highlight.js@^9.15.6:
+  version "9.18.5"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
+  integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -7905,7 +7915,7 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.4.0, json-schema@^0.4.0:
+json-schema@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
   integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
@@ -11213,7 +11223,7 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-trim-off-newlines@^1.0.1, trim-off-newlines@^1.0.3:
+trim-off-newlines@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.3.tgz#8df24847fcb821b0ab27d58ab6efec9f2fe961a1"
   integrity sha512-kh6Tu6GbeSNMGfrrZh6Bb/4ZEHV1QlB4xNDBeog8Y9/QwFlKTRyWvY3Fs9tRDAMZliVUwieMgEdIeL/FtqjkJg==


### PR DESCRIPTION
# Description

Currently there is no timeout for the lumos rpc methods:

```ts
import { RPC } from '@ckb-lumos/rpc'
const rpc = new RPC('YOUR RPC URL')
// if there is something wrong with network or rpc server causing it stuck
// the rpc requests will never return 
await rpc.getBlock("0x1")
```

This pr fixes this by adding a defaut timeout(30 seconds) to the rpc methods and provides a parameter on RPC constructor which user can customize timeout configuration:

```ts
import { RPC } from '@ckb-lumos/rpc'
const rpc = new RPC('YOUR RPC URL', { timeout: 1 }) // milliseconds

// throws time exceeded error
await rpc.getBlock("0x1")
```

## Type of change

- Refactor (non-breaking change)

# How Has This Been Tested?

- An example is provided to test this feature.
- Added test cases
