### PR TITLE
fix(examples): fix omnilock-metamask example bug

### DIFF
--- a/examples/omni-lock-metamask/lib.ts
+++ b/examples/omni-lock-metamask/lib.ts
@@ -120,7 +120,7 @@ export async function transfer(options: Options): Promise<string> {
       "0x" +
         "00".repeat(
           SerializeRcLockWitnessLock({
-            signature: new Uint8Array(65),
+            signature: new Uint8Array(65).buffer,
           }).byteLength
         )
     );
@@ -155,8 +155,8 @@ export async function transfer(options: Options): Promise<string> {
   signedMessage = "0x" + signedMessage.slice(2, -2) + v.toString(16).padStart(2, "0");
 
   const signedWitness = bytes.hexify(blockchain.WitnessArgs.pack({
-    lock: bytes.hexify( SerializeRcLockWitnessLock({
-      signature: bytes.bytify(signedMessage),
+    lock: bytes.hexify(SerializeRcLockWitnessLock({
+      signature: bytes.bytify(signedMessage).buffer,
     })),
   }))
 


### PR DESCRIPTION
# Description

This PR fixes bug in omnilock metamask example, it prompts `Provided value must be an ArrayBuffer or can be transformed into ArrayBuffer!` error before this fix.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- online mannual test https://codesandbox.io/s/github/zhangyouxin/lumos/tree/example-bug/examples/omni-lock-metamask
