### PR TITLE
feat(helpers): verify P2PKH digest with raw tx instead of skeleton 

### DIFF
--- a/packages/helpers/src/validate.ts
+++ b/packages/helpers/src/validate.ts
@@ -1,9 +1,6 @@
 import { BytesLike, bytes } from "@ckb-lumos/codec";
-import { createTransactionFromSkeleton, TransactionSkeletonType } from ".";
-import { blockchain } from "@ckb-lumos/base";
+import { blockchain, RawTransaction } from "@ckb-lumos/base";
 import { CKBHasher } from "@ckb-lumos/base/lib/utils";
-
-const { RawTransaction } = blockchain;
 
 type HashAlgorithm = "ckb-blake2b-256" | "ckb-blake2b-160";
 
@@ -34,13 +31,14 @@ function createHasher(algorithm: HashAlgorithm): Hasher {
  */
 export function validateP2PKHMessage(
   messagesForSigning: BytesLike,
-  txSkeleton: TransactionSkeletonType,
+  rawTransaction: RawTransaction,
   hashContentExceptRawTx: BytesLike,
   hashAlgorithm: HashAlgorithm = "ckb-blake2b-256"
 ): boolean {
   const rawTxHasher = createHasher(hashAlgorithm);
-  const tx = createTransactionFromSkeleton(txSkeleton);
-  const txHash = rawTxHasher.update(RawTransaction.pack(tx)).digestHex();
+  const txHash = rawTxHasher
+    .update(blockchain.RawTransaction.pack(rawTransaction))
+    .digestHex();
 
   const hasher = createHasher(hashAlgorithm);
   hasher.update(txHash);

--- a/packages/helpers/tests/validate.test.ts
+++ b/packages/helpers/tests/validate.test.ts
@@ -12,6 +12,7 @@ import { blockchain } from "@ckb-lumos/base";
 import { validateP2PKHMessage } from "../src/validate";
 import { bytify, hexify } from "@ckb-lumos/codec/lib/bytes";
 import { number, bytes } from "@ckb-lumos/codec";
+import { createTransactionFromSkeleton } from "../src";
 
 const { AGGRON4 } = predefined;
 
@@ -78,7 +79,7 @@ test("simple", (t) => {
   t.true(
     validateP2PKHMessage(
       getMessageForSigning(txSkeleton.signingEntries),
-      txSkeleton,
+      createTransactionFromSkeleton(txSkeleton),
       getHashContentExpectRawTx(txSkeleton),
       "ckb-blake2b-256"
     )
@@ -87,7 +88,7 @@ test("simple", (t) => {
   t.false(
     validateP2PKHMessage(
       bytes.bytifyRawString("KFC CRAZY THURSDAY V ME 50"),
-      txSkeleton,
+      createTransactionFromSkeleton(txSkeleton),
       getHashContentExpectRawTx(txSkeleton),
       "ckb-blake2b-256"
     )
@@ -100,7 +101,7 @@ test("unknown hasher", (t) => {
   t.throws(() => {
     validateP2PKHMessage(
       getMessageForSigning(txSkeleton.signingEntries),
-      txSkeleton,
+      createTransactionFromSkeleton(txSkeleton),
       getHashContentExpectRawTx(txSkeleton),
       "unknown" as any
     );


### PR DESCRIPTION
the new method named `validateP2PKHMessage`'s  function definition is
``` ts
 function validateP2PKHMessage(
  messagesForSigning: BytesLike,
  txSkeleton: TransactionSkeleton,
  hashContentExceptRawTx: BytesLike,
  hashAlgorithm: HashAlgorithm = "ckb-blake2b-256"
): boolean
```
but `TransactionSkeleton` is only in `@ckb-lumos`

# Description
modify the second parameter named `txSkeleton`, rename it to `rawTransaction` with `RawTransaction` type.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Website
- [ ] Example
- [ ] Other

# How Has This Been Tested?

<!--  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Everything use the origin unit test
<!-- 
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules -->