### PR TITLE
feat(bi): add support for unit conversions to BI

### DIFF
--- a/packages/bi/src/index.ts
+++ b/packages/bi/src/index.ts
@@ -190,9 +190,7 @@ export type Unit = "shannon" | "ckb" | number;
 
 const validUnitNames = ["shannon", "ckb"];
 
-export const maxDecimals = 8;
-
-const zeros = Array(maxDecimals).fill("0").join("");
+export const ckbDecimals = 8;
 
 const negativeOne = BI.from(-1);
 
@@ -201,19 +199,17 @@ export function formatUnit(value: BIish, unit: Unit): string {
   return formatFixed(value, decimals);
 }
 
-export function parseUint(value: string, unit: Unit): BI {
+export function parseUnit(value: string, unit: Unit): BI {
   const decimals = parseDecimals(unit);
   return parseFixed(value, decimals);
 }
 
 function formatFixed(value: BIish, decimals: number): string {
   if (!isValidDecimalSize(decimals)) {
-    throw new Error(
-      `decimal size must be within the range of [0-${maxDecimals}]`
-    );
+    throw new Error(`decimal size must be a non-negative integer`);
   }
 
-  const multiplier = "1" + zeros.substring(0, decimals);
+  const multiplier = "1" + Array(decimals).fill("0").join("");
 
   value = BI.from(value);
   const isNegative = value.isNegative();
@@ -242,9 +238,7 @@ function formatFixed(value: BIish, decimals: number): string {
 
 function parseFixed(value: string, decimals: number): BI {
   if (!isValidDecimalSize(decimals)) {
-    throw new Error(
-      `decimal size must be within the range of [0-${maxDecimals}]`
-    );
+    throw new Error(`decimal size must be a non-negative integer`);
   }
 
   // check if value represents a valid decimal number
@@ -252,7 +246,7 @@ function parseFixed(value: string, decimals: number): BI {
     throw new Error("invalid decimal string");
   }
 
-  const multiplier = "1" + zeros.substring(0, decimals);
+  const multiplier = "1" + Array(decimals).fill("0").join("");
 
   const isNegative = value.substring(0, 1) === "-";
 
@@ -319,20 +313,18 @@ function parseDecimals(unit: Unit): number {
       );
     }
     if (unit === "ckb") {
-      decimals = maxDecimals;
+      decimals = ckbDecimals;
     }
   } else {
     if (isValidDecimalSize(unit)) {
       decimals = unit;
     } else {
-      throw new Error(
-        `unit of integer must be within the range of [0-${maxDecimals}]`
-      );
+      throw new Error(`unit of integer must be a non-negative integer`);
     }
   }
   return decimals;
 }
 
 function isValidDecimalSize(decimals: number): boolean {
-  return Number.isInteger(decimals) && decimals >= 0 && decimals <= maxDecimals;
+  return Number.isInteger(decimals) && decimals >= 0;
 }

--- a/packages/bi/tests/index.test.ts
+++ b/packages/bi/tests/index.test.ts
@@ -1,13 +1,5 @@
 import test from "ava";
-import {
-  isBIish,
-  BI,
-  toJSBI,
-  parseUint,
-  formatUnit,
-  maxDecimals,
-  Unit,
-} from "../src/index";
+import { isBIish, BI, toJSBI, parseUnit, formatUnit, Unit } from "../src/index";
 import JSBI from "jsbi";
 
 test("validate if a value is BIish", (t) => {
@@ -220,7 +212,7 @@ test("from JSBI", (t) => {
   t.is(JSBI.equal(toJSBI(bi), jsbi), true);
 });
 
-const invalidUnits = ["whatever", -1, 0.1, 9, maxDecimals + 1];
+const invalidUnits = ["whatever", -1, 0.1];
 
 test("formatUnit", (t) => {
   const invalidValues = ["100.01", "1.0.1", "-.4", "100.0"];
@@ -256,12 +248,12 @@ test("formatUnit", (t) => {
   }
 });
 
-test("parseUint", (t) => {
+test("parseUnit", (t) => {
   const invalidValues = [".", "-", "-.4", "1.0.", "", " "];
   for (const invalidValue of invalidValues) {
     t.throws(
       () => {
-        parseUint(invalidValue, "ckb");
+        parseUnit(invalidValue, "ckb");
       },
       { instanceOf: Error }
     );
@@ -270,7 +262,7 @@ test("parseUint", (t) => {
   for (const invalidUint of invalidUnits) {
     t.throws(
       () => {
-        parseUint("1", <Unit>invalidUint);
+        parseUnit("1", <Unit>invalidUint);
       },
       { instanceOf: Error }
     );
@@ -284,7 +276,7 @@ test("parseUint", (t) => {
   for (const { value, unit } of decimalExceeds) {
     t.throws(
       () => {
-        parseUint(value, <Unit>unit);
+        parseUnit(value, <Unit>unit);
       },
       { instanceOf: Error }
     );
@@ -296,12 +288,13 @@ test("parseUint", (t) => {
     { value: "-0.04", unit: "ckb", result: BI.from(-4e6) },
     { value: "123.321", unit: "ckb", result: BI.from(123321e5) },
     { value: "0.00000001", unit: "ckb", result: BI.from(1) },
+    { value: "100000000", unit: "shannon", result: BI.from(1e8) },
     { value: "0.00000001", unit: 8, result: BI.from(1) },
     { value: "-0.0000001", unit: 8, result: BI.from(-10) },
     { value: "0.0000001", unit: 7, result: BI.from(1) },
-    { value: "100000000", unit: "shannon", result: BI.from(1e8) },
+    { value: "1.1", unit: 18, result: BI.from(11e17) },
   ];
   for (const { value, unit, result } of testCases) {
-    t.is(parseUint(value, <Unit>unit).eq(result), true);
+    t.is(parseUnit(value, <Unit>unit).eq(result), true);
   }
 });

--- a/packages/bi/tests/index.test.ts
+++ b/packages/bi/tests/index.test.ts
@@ -1,5 +1,13 @@
 import test from "ava";
-import { isBIish, BI, toJSBI } from "../src/index";
+import {
+  isBIish,
+  BI,
+  toJSBI,
+  parseUint,
+  formatUnit,
+  maxDecimals,
+  Unit,
+} from "../src/index";
 import JSBI from "jsbi";
 
 test("validate if a value is BIish", (t) => {
@@ -210,4 +218,90 @@ test("from JSBI", (t) => {
   const jsbi = JSBI.BigInt(2);
   t.is(toJSBI(bi) instanceof JSBI, true);
   t.is(JSBI.equal(toJSBI(bi), jsbi), true);
+});
+
+const invalidUnits = ["whatever", -1, 0.1, 9, maxDecimals + 1];
+
+test("formatUnit", (t) => {
+  const invalidValues = ["100.01", "1.0.1", "-.4", "100.0"];
+  for (const invalidValue of invalidValues) {
+    t.throws(
+      () => {
+        formatUnit(invalidValue, "ckb");
+      },
+      { instanceOf: Error }
+    );
+  }
+
+  for (const invalidUint of invalidUnits) {
+    t.throws(
+      () => {
+        formatUnit("1", <Unit>invalidUint);
+      },
+      { instanceOf: Error }
+    );
+  }
+
+  const testCases = [
+    { value: 123000000, unit: "shannon", result: "123000000" },
+    { value: "0x40", unit: "shannon", result: "64" },
+    { value: 123000000, unit: 0, result: "123000000" },
+    { value: 123000000, unit: 2, result: "1230000.0" },
+    { value: 123000000, unit: "ckb", result: "1.23" },
+    { value: BI.from(2), unit: "ckb", result: "0.00000002" },
+    { value: -123404320, unit: 7, result: "-12.340432" },
+  ];
+  for (const { value, unit, result } of testCases) {
+    t.is(formatUnit(value, <Unit>unit), result);
+  }
+});
+
+test("parseUint", (t) => {
+  const invalidValues = [".", "-", "-.4", "1.0.", "", " "];
+  for (const invalidValue of invalidValues) {
+    t.throws(
+      () => {
+        parseUint(invalidValue, "ckb");
+      },
+      { instanceOf: Error }
+    );
+  }
+
+  for (const invalidUint of invalidUnits) {
+    t.throws(
+      () => {
+        parseUint("1", <Unit>invalidUint);
+      },
+      { instanceOf: Error }
+    );
+  }
+
+  const decimalExceeds = [
+    { value: "1.01", unit: "shannon" },
+    { value: "-0.1", unit: "shannon" },
+    { value: "0.000000001", unit: "ckb" },
+  ];
+  for (const { value, unit } of decimalExceeds) {
+    t.throws(
+      () => {
+        parseUint(value, <Unit>unit);
+      },
+      { instanceOf: Error }
+    );
+  }
+
+  const testCases = [
+    { value: "1", unit: "ckb", result: BI.from(1e8) },
+    { value: "-01.00", unit: "ckb", result: BI.from(-1e8) },
+    { value: "-0.04", unit: "ckb", result: BI.from(-4e6) },
+    { value: "123.321", unit: "ckb", result: BI.from(123321e5) },
+    { value: "0.00000001", unit: "ckb", result: BI.from(1) },
+    { value: "0.00000001", unit: 8, result: BI.from(1) },
+    { value: "-0.0000001", unit: 8, result: BI.from(-10) },
+    { value: "0.0000001", unit: 7, result: BI.from(1) },
+    { value: "100000000", unit: "shannon", result: BI.from(1e8) },
+  ];
+  for (const { value, unit, result } of testCases) {
+    t.is(parseUint(value, <Unit>unit).eq(result), true);
+  }
 });

--- a/packages/bi/tests/index.test.ts
+++ b/packages/bi/tests/index.test.ts
@@ -292,7 +292,7 @@ test("parseUnit", (t) => {
     { value: "0.00000001", unit: 8, result: BI.from(1) },
     { value: "-0.0000001", unit: 8, result: BI.from(-10) },
     { value: "0.0000001", unit: 7, result: BI.from(1) },
-    { value: "1.1", unit: 18, result: BI.from(11e17) },
+    { value: "1.1", unit: 18, result: BI.from(10).pow(17).mul(11) },
   ];
   for (const { value, unit, result } of testCases) {
     t.is(parseUnit(value, <Unit>unit).eq(result), true);


### PR DESCRIPTION
# Description

Fixes #420 

## Type of change

- [x] New feature (non-breaking change which adds functionality) that eases the process of unit conversion
  - `function formatUnit(value: BIish, unit: Unit): string`
  -  `function parseUint(value: string, unit: Unit): BI`
