### PR TITLE
feat(ckb-indexer): integrate merged rpc

### DIFF
--- a/packages/ckb-indexer/src/type.ts
+++ b/packages/ckb-indexer/src/type.ts
@@ -8,6 +8,7 @@ import {
   Output,
   TransactionWithStatus,
   Script,
+  Tip,
 } from "@ckb-lumos/base";
 import { EventEmitter } from "events";
 import { BIish } from "@ckb-lumos/bi";
@@ -114,9 +115,7 @@ export type GroupedIndexerTransaction = {
 
 export interface IndexerTransactionList<Grouped extends boolean = false> {
   lastCursor: string | undefined;
-  objects: Grouped extends true
-    ? GroupedIndexerTransaction[]
-    : UngroupedIndexerTransaction[];
+  objects: IndexerTransaction<Grouped>[];
 }
 
 export interface GetCellsResults {
@@ -159,4 +158,22 @@ export interface JsonRprRequestBody {
   jsonrpc: string;
   method: string;
   params: string[];
+}
+
+export interface IndexerRpc {
+  getTip: () => Promise<Tip>;
+
+  getCells<WithData extends boolean = true>(
+    searchKey: GetCellsSearchKey<WithData>,
+    order: Order,
+    limit: HexString,
+    cursor?: string
+  ): Promise<GetLiveCellsResult<WithData>>;
+
+  getTransactions<Grouped extends boolean = false>(
+    searchKey: GetTransactionsSearchKey<Grouped>,
+    order: Order,
+    limit: HexString,
+    cursor?: string
+  ): Promise<IndexerTransactionList<Grouped>>;
 }

--- a/packages/e2e-test/docker/docker-compose.yml
+++ b/packages/e2e-test/docker/docker-compose.yml
@@ -9,19 +9,6 @@ services:
       - internal_network
       - external_network
 
-  ckb-indexer:
-    image: nervos/ckb-indexer:0.4.1
-    ports:
-      - '8130:8116'
-    environment:
-      - RUST_LOG=info
-    command: -s /tmp/ckb-indexer-test -c http://ckb:8114 -l 0.0.0.0:8116
-    depends_on:
-      - ckb
-    networks:
-      - internal_network
-      - external_network
-
 networks:
   internal_network:
     internal: true

--- a/packages/e2e-test/src/constants.ts
+++ b/packages/e2e-test/src/constants.ts
@@ -1,5 +1,4 @@
 export const CKB_RPC_URL = "http://127.0.0.1:8128/rpc";
-export const INDEXER_RPC_URL = "http://127.0.0.1:8130";
 
 // from docker/ckb/dev.toml [[genesis.system_cells]]
 export const GENESIS_CELL_PRIVATEKEYS = [

--- a/packages/e2e-test/src/e2eProvider.ts
+++ b/packages/e2e-test/src/e2eProvider.ts
@@ -7,7 +7,7 @@ import {
   Block,
   Script,
 } from "@ckb-lumos/base";
-import { Indexer, CellCollector } from "@ckb-lumos/ckb-indexer";
+import { Indexer } from "@ckb-lumos/ckb-indexer";
 import {
   CKBIndexerQueryOptions,
   OtherQueryOptions,
@@ -207,11 +207,7 @@ export class E2EProvider {
     queries: CKBIndexerQueryOptions,
     otherQueryOptions?: OtherQueryOptions
   ): Promise<Cell[]> {
-    const cellCollector = new CellCollector(
-      this.indexer,
-      queries,
-      otherQueryOptions
-    );
+    const cellCollector = this.indexer.collector(queries, otherQueryOptions);
 
     const cells: Cell[] = [];
     for await (const cell of cellCollector.collect()) {

--- a/packages/e2e-test/tests/indexer.e2e.test.ts
+++ b/packages/e2e-test/tests/indexer.e2e.test.ts
@@ -1,6 +1,6 @@
 import anyTest, { TestInterface } from "ava";
 import { generateHDAccount, HDAccount } from "../src/utils";
-import { CKB_RPC_URL, INDEXER_RPC_URL } from "../src/constants";
+import { CKB_RPC_URL } from "../src/constants";
 import { E2EProvider } from "../src/e2eProvider";
 import { join } from "path";
 import { FileFaucetQueue } from "../src/faucetQueue";
@@ -22,7 +22,7 @@ interface TestContext {
 const test = anyTest as TestInterface<TestContext>;
 
 const rpc = new RPC(CKB_RPC_URL);
-const indexer = new Indexer(INDEXER_RPC_URL, CKB_RPC_URL);
+const indexer = new Indexer(CKB_RPC_URL);
 
 const faucetQueue = new FileFaucetQueue(join(__dirname, "../tmp/"));
 const e2eProvider = new E2EProvider({ indexer, rpc, faucetQueue: faucetQueue });

--- a/packages/e2e-test/tests/rpc.e2e.test.ts
+++ b/packages/e2e-test/tests/rpc.e2e.test.ts
@@ -1,6 +1,6 @@
 import anyTest, { TestInterface } from "ava";
 import { generateHDAccount, HDAccount } from "../src/utils";
-import { CKB_RPC_URL, INDEXER_RPC_URL } from "../src/constants";
+import { CKB_RPC_URL } from "../src/constants";
 import { E2EProvider } from "../src/e2eProvider";
 import { join } from "path";
 import { FileFaucetQueue } from "../src/faucetQueue";
@@ -22,7 +22,7 @@ interface TestContext {
 const test = anyTest as TestInterface<TestContext>;
 
 const rpc = new RPC(CKB_RPC_URL);
-const indexer = new Indexer(INDEXER_RPC_URL, CKB_RPC_URL);
+const indexer = new Indexer(CKB_RPC_URL);
 
 const faucetQueue = new FileFaucetQueue(join(__dirname, "../tmp/"));
 const e2eProvider = new E2EProvider({ indexer, rpc, faucetQueue: faucetQueue });


### PR DESCRIPTION
# Description

- [x] update @ckb-lumos/ckb-indexer to support merged indexer

Resolved: https://github.com/ckb-js/lumos/issues/416

This is a no breaking change PR

With the [merged indexer](https://github.com/nervosnetwork/ckb/pull/3609), we no longer need to depend on a separate ckb-indexer

```ts
import { Indexer } from '@ckb-lumos/lumos';

// before
// const indexer = new Indexer(
//   "https://testnet.ckb.dev/indexer", 
//   "https://testnet.ckb.dev/rpc",
// );

// after
const indexer = new Indexer("https://testnet.ckb.dev/rpc");
```

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Website
- [ ] Example
- [ ] Other

# How Has This Been Tested?

- [x] pass e2e test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->