### PR TITLE
fix: light-client get_transactions rpc response is inconsistent

### DIFF
--- a/packages/e2e-test/tests/light-client-rpc.e2e.test.ts
+++ b/packages/e2e-test/tests/light-client-rpc.e2e.test.ts
@@ -192,7 +192,7 @@ test.serial("light-client get_transactions rpc", async (t) => {
     "0x64"
   );
 
-  t.deepEqual(unGrouped.objects.length, alice.cells.length);
+  t.deepEqual(ungrouped.objects.length, alice.cells.length);
   t.deepEqual(
     unGrouped.objects.map((obj) => obj.blockNumber),
     alice.cells.map((cell) => cell.blockNumber)

--- a/packages/e2e-test/tests/light-client-rpc.e2e.test.ts
+++ b/packages/e2e-test/tests/light-client-rpc.e2e.test.ts
@@ -217,7 +217,7 @@ test.serial("light-client get_transactions rpc", async (t) => {
 
   t.deepEqual(
     grouped.objects.map((o) => o.transaction),
-    unGrouped.objects.map((o) => o.transaction)
+    ungrouped.objects.map((o) => o.transaction)
   );
 });
 

--- a/packages/e2e-test/tests/light-client-rpc.e2e.test.ts
+++ b/packages/e2e-test/tests/light-client-rpc.e2e.test.ts
@@ -183,7 +183,7 @@ test.serial("light-client get_transactions rpc", async (t) => {
     parseInt(alice.cells[alice.cells.length - 1].blockNumber || "0x0")
   );
 
-  const unGrouped = await lightClientRPC.getTransactions(
+  const ungrouped = await lightClientRPC.getTransactions(
     {
       script: alice.lockScript,
       scriptType: "lock",

--- a/packages/e2e-test/tests/light-client-rpc.e2e.test.ts
+++ b/packages/e2e-test/tests/light-client-rpc.e2e.test.ts
@@ -194,7 +194,7 @@ test.serial("light-client get_transactions rpc", async (t) => {
 
   t.deepEqual(ungrouped.objects.length, alice.cells.length);
   t.deepEqual(
-    unGrouped.objects.map((obj) => obj.blockNumber),
+    ungrouped.objects.map((obj) => obj.blockNumber),
     alice.cells.map((cell) => cell.blockNumber)
   );
 

--- a/packages/light-client/src/rpc.ts
+++ b/packages/light-client/src/rpc.ts
@@ -4,7 +4,6 @@ import { ParamsFormatter } from "@ckb-lumos/rpc";
 
 import {
   GetLiveCellsResult,
-  IndexerTransactionList,
   Order,
   SearchKey,
   GetCellsSearchKey,
@@ -21,6 +20,7 @@ import {
   FetchTransactionResult,
   LightClientScript,
   TransactionWithHeader,
+  LightClientTransactionList,
 } from "./type";
 import fetch from "cross-fetch";
 
@@ -108,7 +108,7 @@ export class LightClientRPC {
     order: Order,
     limit: HexString,
     cursor?: string
-  ): Promise<IndexerTransactionList<Grouped>> {
+  ): Promise<LightClientTransactionList<Grouped>> {
     const params = [
       toGetTransactionsSearchKey(searchKey),
       order,

--- a/packages/light-client/src/type.ts
+++ b/packages/light-client/src/type.ts
@@ -26,6 +26,34 @@ export type FetchTransactionResult =
   | { status: FetchFlag.Added; timestamp: string }
   | { status: FetchFlag.NotFound };
 
+export interface LightClientTransactionList<Grouped extends boolean = false> {
+  lastCursor: string | undefined;
+  objects: LightClientTransaction<Grouped>[];
+}
+
+export type LightClientTransaction<Goruped extends boolean = false> =
+  Goruped extends true
+    ? GroupedLightClientTransaction
+    : UngroupedLightClientTransaction;
+
+export type HexNum = string;
+export type IOType = "input" | "output" | "both";
+
+export type UngroupedLightClientTransaction = {
+  transaction: Transaction;
+  blockNumber: HexNum;
+  ioIndex: HexNum;
+  ioType: IOType;
+  txIndex: HexNum;
+};
+
+export type GroupedLightClientTransaction = {
+  transaction: Transaction;
+  blockNumber: HexNum;
+  txIndex: HexNum;
+  cells: Array<[IOType, HexNum]>;
+};
+
 export type LightClientScript = {
   script: Script;
   blockNumber: HexNumber;


### PR DESCRIPTION
# Description

- [x] fix `get_transactions` rpc's response is inconsistent

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] test `get_transactions` rpc & check response type

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules