### PR TITLE
fix: e2e-test timeout error

### DIFF
--- a/packages/e2e-test/docker/light-client/Dockerfile
+++ b/packages/e2e-test/docker/light-client/Dockerfile
@@ -13,7 +13,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
     curl
 
-RUN curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/latest | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && chmod +x dasel
+RUN curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/80229218 | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && chmod +x dasel
 RUN mv ./dasel /usr/local/bin/dasel
 
 FROM ubuntu:bionic


### PR DESCRIPTION
# Description

change docker file to solve the problem that e2e-tests timeout in ci.


## Type of change
- [x] Other

# How Has This Been Tested?
- [x] pass all test
