### PR TITLE
chore: remove compute script hash second parameter

### DIFF
--- a/packages/base/src/utils.ts
+++ b/packages/base/src/utils.ts
@@ -49,12 +49,8 @@ function ckbHash(data: BytesLike): Hash {
  * compute lock/type hash
  *
  * @param script
- * @param _options @deprecated this option has no effect
  */
-function computeScriptHash(
-  script: Script,
-  _options?: { validate?: boolean }
-): string {
+function computeScriptHash(script: Script): string {
   return ckbHash(blockchain.Script.pack(script));
 }
 

--- a/website/docs/migrations/migrate-to-v0.20.md
+++ b/website/docs/migrations/migrate-to-v0.20.md
@@ -1,4 +1,21 @@
 # Migration to Lumos 0.20
 
+## Browser shiming
+
 If you are using Lumos in the browser, please add configuration according to
 this [doc](../recipes/cra-vite-webpack-or-other)
+
+## Remove `computeScriptHash` Second Parameter
+
+In an early version, we make the second parameter be ignored in it's implement.
+
+Now we fully remove it.
+
+```ts
+import { utils } from "@ckb-lumos/lumos"
+// before
+const scriptHash = computeScriptHash(script, option)
+// Just remove the second parameter in your code 👆
+// after
+const scriptHash = computeScriptHash(script)
+```


### PR DESCRIPTION
# Description
In early version, we make secend parameter of [computeScriptHash](https://lumos-website-git-develop-cryptape.vercel.app/api/modules/base.html#computescripthash) be ignored.

Now we should fully remove it.

In addtional, some editor(Like VSCode), will apply `@deprecated` as total function, not the parameter. It may take confuse to our user.
 
![image](https://user-images.githubusercontent.com/20639676/211230573-167165c4-f13d-4fa4-97b2-9b44bb605af2.png)

This PR do two things:

1. remove the second parameter `option` on function signature and tsdoc
2. A simple guide for migration

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation or Website
- [ ] Example
- [ ] Other

# How Has This Been Tested?

<!--  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [x] Pass origin unit test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules