### PR TITLE
chore: ci failed since incorrect dasel ver

### DIFF
--- a/packages/e2e-test/docker/light-client/Dockerfile
+++ b/packages/e2e-test/docker/light-client/Dockerfile
@@ -13,7 +13,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
     curl
 
-RUN curl -sSLf "$(curl -sSLf https://api.github.com/repos/tomwright/dasel/releases/80229218 | grep browser_download_url | grep linux_amd64 | grep -v .gz | cut -d\" -f 4)" -L -o dasel && chmod +x dasel
+RUN curl -sSLf "https://github.com/TomWright/dasel/releases/download/v1.27.3/dasel_linux_amd64" -L -o dasel && chmod +x dasel
 RUN mv ./dasel /usr/local/bin/dasel
 
 FROM ubuntu:bionic


### PR DESCRIPTION
Because there were changes in the dasel command in `version 2`
- https://daseldocs.tomwright.me/#v1-to-v2-breaking-changes
dasel cannot run properly in the `entrypoint.sh` script
- https://github.com/gpBlockchain/lumos/blob/24bbc4e0b2da0ec6da611516623b3de8e1bbf50b/packages/e2e-test/docker/light-client/entrypoint.sh#L5-L8
 Therefore, either the version number must be fixed or the syntax in the `entrypoint.sh`  script must be upgraded. In this case, a simple approach is adopted, which is to directly pull the fixed version of dasel to ensure that the dasel syntax can run properly.

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation or Website
- [ ] Example
- [ ] Other

# How Has This Been Tested?

<!--  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

<!-- 
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->