### PR TITLE
feat(ckb-indexer): fix loadCells DoS vuln. Support the exact search mode

### DIFF
--- a/examples/ckb-indexer-collector.ts
+++ b/examples/ckb-indexer-collector.ts
@@ -2,40 +2,20 @@
 
 import { Script, Indexer, helpers, config, BI } from "@ckb-lumos/lumos";
 
-config.initializeConfig(config.predefined.LINA);
+config.initializeConfig(config.predefined.AGGRON4);
 
-const nodeUri = "https://testnet.ckb.dev/rpc";
-const indexUri = "https://testnet.ckb.dev/indexer";
-const indexer = new Indexer(indexUri, nodeUri);
+const CKB_RPC_URL = "https://testnet.ckb.dev/rpc";
+const indexer = new Indexer(CKB_RPC_URL);
 
 async function capacityOf(lock: Script): Promise<BI> {
   const collector = indexer.collector({ lock });
 
   let balance: BI = BI.from(0);
-  
   for await (const cell of collector.collect()) {
     balance = balance.add(cell.cellOutput.capacity);
   }
 
   return balance;
-}
-
-async function exact_cell_collector() {
-  const address = "ckt1qyq97krr9gfrulnnrkctt889plsk27w8m9qsetfrg0";
-  const lock:Script = {
-            codeHash:
-            "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-            hashType: "type",
-            args: "0x5f58632a123e7e731db0b59ce50fe16579c7d941",
-        }
-
-  const balance = await capacityOf(lock);
-
-  const integer = balance.div(BI.from(10).pow(8));
-  const fraction = balance.mod(BI.from(10).pow(8));
-
-  console.log(`lock of ${address} is`, lock, "\n");
-  console.log(`total CKB of ${address} is ${integer + "." + fraction}`);
 }
 
 async function main() {
@@ -52,4 +32,3 @@ async function main() {
 }
 
 main();
-exact_cell_collector();

--- a/examples/ckb-indexer-collector.ts
+++ b/examples/ckb-indexer-collector.ts
@@ -2,20 +2,40 @@
 
 import { Script, Indexer, helpers, config, BI } from "@ckb-lumos/lumos";
 
-config.initializeConfig(config.predefined.AGGRON4);
+config.initializeConfig(config.predefined.LINA);
 
-const CKB_RPC_URL = "https://testnet.ckb.dev/rpc";
-const indexer = new Indexer(CKB_RPC_URL);
+const nodeUri = "https://testnet.ckb.dev/rpc";
+const indexUri = "https://testnet.ckb.dev/indexer";
+const indexer = new Indexer(indexUri, nodeUri);
 
 async function capacityOf(lock: Script): Promise<BI> {
   const collector = indexer.collector({ lock });
 
   let balance: BI = BI.from(0);
+  
   for await (const cell of collector.collect()) {
     balance = balance.add(cell.cellOutput.capacity);
   }
 
   return balance;
+}
+
+async function exact_cell_collector() {
+  const address = "ckt1qyq97krr9gfrulnnrkctt889plsk27w8m9qsetfrg0";
+  const lock:Script = {
+            codeHash:
+            "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+            hashType: "type",
+            args: "0x5f58632a123e7e731db0b59ce50fe16579c7d941",
+        }
+
+  const balance = await capacityOf(lock);
+
+  const integer = balance.div(BI.from(10).pow(8));
+  const fraction = balance.mod(BI.from(10).pow(8));
+
+  console.log(`lock of ${address} is`, lock, "\n");
+  console.log(`total CKB of ${address} is ${integer + "." + fraction}`);
 }
 
 async function main() {
@@ -32,3 +52,4 @@ async function main() {
 }
 
 main();
+exact_cell_collector();

--- a/examples/load_cell_test.ts
+++ b/examples/load_cell_test.ts
@@ -3,25 +3,6 @@ const nodeUri = "https://testnet.ckb.dev/rpc";
 const indexUri = "https://testnet.ckb.dev/indexer";
 const indexer = new Indexer(indexUri, nodeUri);
 
-
-const bootstrap = async () => {
-    const cellCollector = indexer.collector({
-        lock: {
-            codeHash:
-            "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
-            hashType: "type",
-            args: "0x5f58632a123e7e731db0b59ce50fe16579c7d941",
-        },
-        scriptSearchMode: "prefix",
-    });
-
-    for await (const cell of cellCollector.collect()) {
-        console.log(cell);
-    }
-}
-
-bootstrap()
-
 const exact_cell_collector = async () => {
     const cellCollector = indexer.collector({
         lock: {

--- a/examples/load_cell_test.ts
+++ b/examples/load_cell_test.ts
@@ -1,0 +1,51 @@
+import { Indexer } from "@ckb-lumos/ckb-indexer";
+const nodeUri = "https://testnet.ckb.dev/rpc";
+const indexUri = "https://testnet.ckb.dev/indexer";
+const indexer = new Indexer(indexUri, nodeUri);
+
+
+const bootstrap = async () => {
+    const cellCollector = indexer.collector({
+        lock: {
+            codeHash:
+            "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+            hashType: "type",
+            args: "0x5f58632a123e7e731db0b59ce50fe16579c7d941",
+        },
+        scriptSearchMode: "prefix",
+    });
+
+    for await (const cell of cellCollector.collect()) {
+        console.log(cell);
+    }
+}
+
+bootstrap()
+
+const exact_cell_collector = async () => {
+    const cellCollector = indexer.collector({
+        lock: {
+            codeHash:
+            "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+            hashType: "type",
+            args: "0x5f58632a123e7e731db0b59ce50fe16579c7d941",
+        },
+        scriptSearchMode: "exact",
+    });
+
+    let exact_flag:boolean = true
+
+    for await (const cell of cellCollector.collect()) {
+        console.log(cell);
+        if(cell.cellOutput.lock.args.endsWith("01")){
+            exact_flag = false
+            console.log("[-] Error. Still Prefix Search which could be DoS.")
+        }
+    }
+
+    if(exact_flag){
+        console.log("[+] Yeah. Exact Search Support to Collector")
+    }
+}
+
+exact_cell_collector()

--- a/examples/secp256k1-transfer/package.json
+++ b/examples/secp256k1-transfer/package.json
@@ -15,8 +15,8 @@
     "@ckb-lumos/lumos": "0.20.0-alpha.1",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.0",

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -5601,7 +5601,7 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-dom@18.2.0:
+react-dom@18.2.0, react-dom@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
   integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
@@ -5649,7 +5649,7 @@ react-use@^17.4.0:
     ts-easing "^0.2.0"
     tslib "^2.1.0"
 
-react@18.2.0:
+react@18.2.0, react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
@@ -5863,6 +5863,11 @@ screenfull@^5.1.0:
   version "5.2.0"
   resolved "https://registry.npmmirror.com/screenfull/-/screenfull-5.2.0.tgz#6533d524d30621fc1283b9692146f3f13a93d1ba"
   integrity sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==
+
+scrypt-js@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
+  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
 
 seek-bzip@^1.0.5:
   version "1.0.6"

--- a/package.json
+++ b/package.json
@@ -82,5 +82,8 @@
   },
   "website/{docs,src}/**/*.{js,ts,md}": [
     "prettier --write"
-  ]
+  ],
+  "dependencies": {
+    "@nervosnetwork/ckb-sdk-core": "^0.103.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -82,8 +82,5 @@
   },
   "website/{docs,src}/**/*.{js,ts,md}": [
     "prettier --write"
-  ],
-  "dependencies": {
-    "@nervosnetwork/ckb-sdk-core": "^0.103.1"
-  }
+  ]
 }

--- a/packages/ckb-indexer/src/paramsFormatter.ts
+++ b/packages/ckb-indexer/src/paramsFormatter.ts
@@ -27,7 +27,7 @@ const toSearchKey = (data: SearchKey): RPCType.SearchKey => ({
   script: toScript(data.script),
   script_type: data.scriptType,
   filter: data.filter ? toSearchFilter(data.filter) : data.filter,
-  script_search_mode: data.scriptSearchMode ? data.scriptSearchMode : "prefix"
+  script_search_mode: data.scriptSearchMode ? data.scriptSearchMode : "prefix",
 });
 
 const toGetCellsSearchKey = (

--- a/packages/ckb-indexer/src/paramsFormatter.ts
+++ b/packages/ckb-indexer/src/paramsFormatter.ts
@@ -27,6 +27,7 @@ const toSearchKey = (data: SearchKey): RPCType.SearchKey => ({
   script: toScript(data.script),
   script_type: data.scriptType,
   filter: data.filter ? toSearchFilter(data.filter) : data.filter,
+  script_search_mode: data.scriptSearchMode ? data.scriptSearchMode : "prefix"
 });
 
 const toGetCellsSearchKey = (

--- a/packages/ckb-indexer/src/resultFormatter.ts
+++ b/packages/ckb-indexer/src/resultFormatter.ts
@@ -36,7 +36,7 @@ const toSearchKey = (data: RPCType.SearchKey): SearchKey => ({
   script: toScript(data.script),
   scriptType: data.script_type,
   filter: data.filter ? toSearchFilter(data.filter) : data.filter,
-  scriptSearchMode: data.script_search_mode
+  scriptSearchMode: data.script_search_mode,
 });
 
 export {

--- a/packages/ckb-indexer/src/resultFormatter.ts
+++ b/packages/ckb-indexer/src/resultFormatter.ts
@@ -36,6 +36,7 @@ const toSearchKey = (data: RPCType.SearchKey): SearchKey => ({
   script: toScript(data.script),
   scriptType: data.script_type,
   filter: data.filter ? toSearchFilter(data.filter) : data.filter,
+  scriptSearchMode: data.script_search_mode
 });
 
 export {

--- a/packages/ckb-indexer/src/rpcType.ts
+++ b/packages/ckb-indexer/src/rpcType.ts
@@ -21,6 +21,7 @@ export type CellOutput = {
 
 export type HexadecimalRange = [Hexadecimal, Hexadecimal];
 export type ScriptType = "type" | "lock";
+export type ScriptSearchMode = "prefix" | "exact";
 
 export interface SearchFilter {
   script?: Script;
@@ -33,6 +34,7 @@ export interface SearchKey {
   script: Script;
   script_type: ScriptType;
   filter?: SearchFilter;
+  script_search_mode?: ScriptSearchMode;
 }
 export interface GetCellsSearchKey extends SearchKey {
   with_data?: boolean;

--- a/packages/ckb-indexer/src/services.ts
+++ b/packages/ckb-indexer/src/services.ts
@@ -19,6 +19,7 @@ const generateSearchKey = (queries: CKBIndexerQueryOptions): SearchKey => {
   let script: RPCType.Script | undefined = undefined;
   const filter: RPCType.SearchFilter = {};
   let script_type: RPCType.ScriptType | undefined = undefined;
+  let script_search_mode: RPCType.ScriptSearchMode = "prefix";
   if (queries.lock) {
     const lock = UnwrapScriptWrapper(queries.lock);
     script = toScript(lock);
@@ -52,6 +53,9 @@ const generateSearchKey = (queries: CKBIndexerQueryOptions): SearchKey => {
   if (queries.scriptLenRange) {
     filter.script_len_range = queries.scriptLenRange;
   }
+  if (queries.scriptSearchMode) {
+    script_search_mode = queries.scriptSearchMode;
+  }
   if (!script) {
     throw new Error("Either lock or type script must be provided!");
   }
@@ -62,6 +66,7 @@ const generateSearchKey = (queries: CKBIndexerQueryOptions): SearchKey => {
     script,
     script_type,
     filter,
+    script_search_mode
   });
 };
 

--- a/packages/ckb-indexer/src/services.ts
+++ b/packages/ckb-indexer/src/services.ts
@@ -66,7 +66,7 @@ const generateSearchKey = (queries: CKBIndexerQueryOptions): SearchKey => {
     script,
     script_type,
     filter,
-    script_search_mode
+    script_search_mode,
   });
 };
 

--- a/packages/ckb-indexer/src/type.ts
+++ b/packages/ckb-indexer/src/type.ts
@@ -15,6 +15,7 @@ import { BIish } from "@ckb-lumos/bi";
 
 export type ScriptType = "type" | "lock";
 export type Order = "asc" | "desc";
+export type ScriptSearchMode = "prefix" | "exact";
 
 export interface CKBIndexerQueryOptions extends QueryOptions {
   outputDataLenRange?: HexadecimalRange;
@@ -23,6 +24,7 @@ export interface CKBIndexerQueryOptions extends QueryOptions {
   bufferSize?: number;
   withData?: boolean;
   groupByTransaction?: boolean;
+  scriptSearchMode?: ScriptSearchMode;
 }
 
 export type HexadecimalRange = [Hexadecimal, Hexadecimal];
@@ -36,6 +38,7 @@ export interface SearchFilter {
 export interface SearchKey {
   script: Script;
   scriptType: ScriptType;
+  scriptSearchMode?: ScriptSearchMode;
   filter?: SearchFilter;
 }
 export interface GetLiveCellsResult<WithData extends boolean = true> {

--- a/packages/rpc/src/paramsFormatter.ts
+++ b/packages/rpc/src/paramsFormatter.ts
@@ -180,6 +180,7 @@ export const formatter = {
       script: formatter.toScript(data.script),
       script_type: data.scriptType,
       filter: data.filter ? formatter.toSearchFilter(data.filter) : data.filter,
+      script_search_mode: data.scriptSearchMode ? data.scriptSearchMode : "prefix",
     };
   },
   toGetCellsSearchKey: (

--- a/packages/rpc/src/paramsFormatter.ts
+++ b/packages/rpc/src/paramsFormatter.ts
@@ -180,7 +180,9 @@ export const formatter = {
       script: formatter.toScript(data.script),
       script_type: data.scriptType,
       filter: data.filter ? formatter.toSearchFilter(data.filter) : data.filter,
-      script_search_mode: data.scriptSearchMode ? data.scriptSearchMode : "prefix",
+      script_search_mode: data.scriptSearchMode
+        ? data.scriptSearchMode
+        : "prefix",
     };
   },
   toGetCellsSearchKey: (

--- a/packages/rpc/src/types/api.ts
+++ b/packages/rpc/src/types/api.ts
@@ -178,6 +178,7 @@ export namespace CKBComponents {
   export type ScriptType = "type" | "lock";
   export type Order = "asc" | "desc";
   export type IOType = "input" | "output" | "both";
+  export type ScriptSearchMode = "prefix" | "exact";
 
   export interface IndexerCell {
     blockNumber: BlockNumber;
@@ -247,6 +248,7 @@ export namespace CKBComponents {
     script: Script;
     scriptType: ScriptType;
     filter?: SearchFilter;
+    scriptSearchMode?: ScriptSearchMode;
   }
   export interface GetLiveCellsResult<WithData extends boolean = true> {
     lastCursor: string;

--- a/packages/rpc/src/types/rpc.ts
+++ b/packages/rpc/src/types/rpc.ts
@@ -394,6 +394,7 @@ export namespace RPC {
 
   export type HexadecimalRange = [string, string];
   export type ScriptType = "type" | "lock";
+  export type ScriptSearchMode = "prefix" | "exact";
 
   export interface SearchFilter {
     script?: Script;
@@ -406,6 +407,7 @@ export namespace RPC {
     script: Script;
     script_type: ScriptType;
     filter?: SearchFilter;
+    script_search_mode?: ScriptSearchMode;
   }
   export interface GetCellsSearchKey extends SearchKey {
     with_data?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2116,6 +2116,41 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
+"@nervosnetwork/ckb-sdk-core@^0.103.1":
+  version "0.103.1"
+  resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-sdk-core/-/ckb-sdk-core-0.103.1.tgz#136d616ec53af96d3b93dcbce593e6db484c802d"
+  integrity sha512-LeNwId3GaQILVpnY1zfNBY897XQJPODKeP6d7w6tww9anu0jSxrvXVxGMDTTn3Yz5mixzBgpFGo4SXRrH0eiaQ==
+  dependencies:
+    "@nervosnetwork/ckb-sdk-rpc" "0.103.1"
+    "@nervosnetwork/ckb-sdk-utils" "0.103.1"
+    "@nervosnetwork/ckb-types" "0.103.1"
+    tslib "2.3.1"
+
+"@nervosnetwork/ckb-sdk-rpc@0.103.1":
+  version "0.103.1"
+  resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-sdk-rpc/-/ckb-sdk-rpc-0.103.1.tgz#6c0d0bad8a05a9280ddc34adf973bf55e0725e06"
+  integrity sha512-n3V/5Be7PilyHXUcR6yAiwanMcuZNLfslu9A84OpfB22hlkwIv7OFG/JvFNack/cANPfChRAWB+VWiYGwSON/A==
+  dependencies:
+    "@nervosnetwork/ckb-sdk-utils" "0.103.1"
+    axios "0.21.4"
+    tslib "2.3.1"
+
+"@nervosnetwork/ckb-sdk-utils@0.103.1":
+  version "0.103.1"
+  resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-sdk-utils/-/ckb-sdk-utils-0.103.1.tgz#8356f88027a4054835fee0648617cc7020c8db1b"
+  integrity sha512-OzpFNKkOOqYWDHDjPf11uOfOf8EQOEstOBxVtyFjrGEx3B9FwsGxItlHYeuTfpFkHF2Ut+G9M3X71w8h/IApdQ==
+  dependencies:
+    "@nervosnetwork/ckb-types" "0.103.1"
+    bech32 "2.0.0"
+    elliptic "6.5.4"
+    jsbi "3.1.3"
+    tslib "2.3.1"
+
+"@nervosnetwork/ckb-types@0.103.1":
+  version "0.103.1"
+  resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-types/-/ckb-types-0.103.1.tgz#b5626ce905353e70136bfaccf9def0819b76ca27"
+  integrity sha512-gGRR1VvUS/KRq2ChhXHPiHpgyLYazPM2R8lK87shQI82Gp2/m6k1HVDeNR5XOYwQ3YmBbxHGQtQr/kMq7DUlZA==
+
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz#323d72dd25103d0c4fbdce89dadf574a787b1f9b"
@@ -3099,12 +3134,7 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
-
-ansi-regex@^5.0.1:
+ansi-regex@^2.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -3494,7 +3524,7 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bech32@^2.0.0:
+bech32@2.0.0, bech32@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
   integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
@@ -4836,7 +4866,7 @@ electron-to-chromium@^1.4.188:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.200.tgz#6e4c5266106688965b4ea7caa11f0dd315586854"
   integrity sha512-nPyI7oHc8T64oSqRXrAt99gNMpk0SAgPHw/o+hkNKyb5+bcdnFtZcSO9FUJES5cVkVZvo8u4qiZ1gQILl8UXsA==
 
-elliptic@^6.5.3, elliptic@^6.5.4:
+elliptic@6.5.4, elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -6030,15 +6060,10 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-highlight.js@^10.0.0:
+highlight.js@^10.0.0, highlight.js@^10.4.1, highlight.js@^9.15.6:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
-
-highlight.js@^9.15.6:
-  version "9.18.5"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
-  integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -7050,6 +7075,11 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+jsbi@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-3.1.3.tgz#f024b340032f7c7caaa6ca4b32b55e8d33f6e897"
+  integrity sha512-nBJqA0C6Qns+ZxurbEoIR56wyjiUszpNy70FHvxO5ervMoCbZVE3z3kxr5nKGhlxr/9MhKTSUBs7cAwwuf3g9w==
+
 jsbi@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-4.3.0.tgz#b54ee074fb6fcbc00619559305c8f7e912b04741"
@@ -7100,7 +7130,7 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.4.0:
+json-schema@0.4.0, json-schema@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
   integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
@@ -10293,7 +10323,7 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-trim-off-newlines@^1.0.1:
+trim-off-newlines@^1.0.1, trim-off-newlines@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.3.tgz#8df24847fcb821b0ab27d58ab6efec9f2fe961a1"
   integrity sha512-kh6Tu6GbeSNMGfrrZh6Bb/4ZEHV1QlB4xNDBeog8Y9/QwFlKTRyWvY3Fs9tRDAMZliVUwieMgEdIeL/FtqjkJg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2116,41 +2116,6 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
-"@nervosnetwork/ckb-sdk-core@^0.103.1":
-  version "0.103.1"
-  resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-sdk-core/-/ckb-sdk-core-0.103.1.tgz#136d616ec53af96d3b93dcbce593e6db484c802d"
-  integrity sha512-LeNwId3GaQILVpnY1zfNBY897XQJPODKeP6d7w6tww9anu0jSxrvXVxGMDTTn3Yz5mixzBgpFGo4SXRrH0eiaQ==
-  dependencies:
-    "@nervosnetwork/ckb-sdk-rpc" "0.103.1"
-    "@nervosnetwork/ckb-sdk-utils" "0.103.1"
-    "@nervosnetwork/ckb-types" "0.103.1"
-    tslib "2.3.1"
-
-"@nervosnetwork/ckb-sdk-rpc@0.103.1":
-  version "0.103.1"
-  resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-sdk-rpc/-/ckb-sdk-rpc-0.103.1.tgz#6c0d0bad8a05a9280ddc34adf973bf55e0725e06"
-  integrity sha512-n3V/5Be7PilyHXUcR6yAiwanMcuZNLfslu9A84OpfB22hlkwIv7OFG/JvFNack/cANPfChRAWB+VWiYGwSON/A==
-  dependencies:
-    "@nervosnetwork/ckb-sdk-utils" "0.103.1"
-    axios "0.21.4"
-    tslib "2.3.1"
-
-"@nervosnetwork/ckb-sdk-utils@0.103.1":
-  version "0.103.1"
-  resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-sdk-utils/-/ckb-sdk-utils-0.103.1.tgz#8356f88027a4054835fee0648617cc7020c8db1b"
-  integrity sha512-OzpFNKkOOqYWDHDjPf11uOfOf8EQOEstOBxVtyFjrGEx3B9FwsGxItlHYeuTfpFkHF2Ut+G9M3X71w8h/IApdQ==
-  dependencies:
-    "@nervosnetwork/ckb-types" "0.103.1"
-    bech32 "2.0.0"
-    elliptic "6.5.4"
-    jsbi "3.1.3"
-    tslib "2.3.1"
-
-"@nervosnetwork/ckb-types@0.103.1":
-  version "0.103.1"
-  resolved "https://registry.yarnpkg.com/@nervosnetwork/ckb-types/-/ckb-types-0.103.1.tgz#b5626ce905353e70136bfaccf9def0819b76ca27"
-  integrity sha512-gGRR1VvUS/KRq2ChhXHPiHpgyLYazPM2R8lK87shQI82Gp2/m6k1HVDeNR5XOYwQ3YmBbxHGQtQr/kMq7DUlZA==
-
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz#323d72dd25103d0c4fbdce89dadf574a787b1f9b"
@@ -3524,7 +3489,7 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bech32@2.0.0, bech32@^2.0.0:
+bech32@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
   integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
@@ -4866,7 +4831,7 @@ electron-to-chromium@^1.4.188:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.200.tgz#6e4c5266106688965b4ea7caa11f0dd315586854"
   integrity sha512-nPyI7oHc8T64oSqRXrAt99gNMpk0SAgPHw/o+hkNKyb5+bcdnFtZcSO9FUJES5cVkVZvo8u4qiZ1gQILl8UXsA==
 
-elliptic@6.5.4, elliptic@^6.5.3, elliptic@^6.5.4:
+elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -7074,11 +7039,6 @@ js-yaml@^4.1.0:
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
-
-jsbi@3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-3.1.3.tgz#f024b340032f7c7caaa6ca4b32b55e8d33f6e897"
-  integrity sha512-nBJqA0C6Qns+ZxurbEoIR56wyjiUszpNy70FHvxO5ervMoCbZVE3z3kxr5nKGhlxr/9MhKTSUBs7cAwwuf3g9w==
 
 jsbi@^4.1.0:
   version "4.3.0"


### PR DESCRIPTION
# Description

loadCell or Collector needs exact-search-mode support. otherwise there's the DoS vulnerability about any Dapps rely on the lumos

Fixes #488 

## Type of change

- [ x ] Bug fix ( transfer DoS of lumos )
- [ x ] New feature ( support exact-search-mode for collector )

# How Has This Been Tested?
``` sh
git clone git@github.com:LiRiu/lumos.git
cd lumos
yarn build
yarn build-release
yarn ts-node examples/load_cell_test.ts
```

- [ x ] Test `bootstrap` for prefix_search mode 
- [ x ] Test `exact_cell_collector` for exact_search mode which should be used in Dapp's transfer module.
