### PR TITLE
feat: allow data1 scripts in config.json

### DIFF
--- a/packages/config-manager/src/manager.ts
+++ b/packages/config-manager/src/manager.ts
@@ -42,9 +42,9 @@ export function validateConfig(config: Config): void {
 
     assertHash(`SCRIPTS.${scriptName}.CODE_HASH`, scriptConfig.CODE_HASH);
     const hashType = scriptConfig.HASH_TYPE;
-    if (hashType !== "type" && hashType !== "data") {
+    if (hashType !== "type" && hashType !== "data" && hashType !== "data1") {
       throw new Error(
-        `SCRIPTS.${scriptName}.HASH_TYPE must either be data or type!`
+        `SCRIPTS.${scriptName}.HASH_TYPE must be type, data or data1!`
       );
     }
     assertHash(`SCRIPTS.${scriptName}.TX_HASH`, scriptConfig.TX_HASH);


### PR DESCRIPTION
# Description

Allow data1 scripts in config.json

Fixes #498

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

It has not been tested. The rest of the code-base should be already `data1` ready, this restrictive check was forgotten in the change to `vm2021`.

Feel free to add tests! :hugs: