### PR TITLE
chore: non-existent job in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ permissions:
 jobs:
   release:
     name: Release
-    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 5
 


### PR DESCRIPTION
I forgot to remove the unnecessary `test` job from the workflow. 

The `release` job will open a [pull request titled "Version Packages"](https://github.com/homura/lumos-experimental/pull/3) by the `changesets/develop` branch, it always up to date with `develop`, and the pull request workflows have contained all tests, therefor, the `needs: test` is redundant