### PR TITLE
fix(common-scripts): sudt data may over 16 bytes

### DIFF
--- a/.changeset/orange-flowers-sort.md
+++ b/.changeset/orange-flowers-sort.md
@@ -1,0 +1,5 @@
+---
+"@ckb-lumos/common-scripts": patch
+---
+
+enable ACP to work with cells with more than 16 bytes of data

--- a/.changeset/orange-flowers-sort.md
+++ b/.changeset/orange-flowers-sort.md
@@ -2,4 +2,4 @@
 "@ckb-lumos/common-scripts": patch
 ---
 
-enable ACP to work with cells with more than 16 bytes of data
+enable ACP to work with sUDT cells with more than 16 bytes of data

--- a/examples/exchange-sudt-for-ckb/package.json
+++ b/examples/exchange-sudt-for-ckb/package.json
@@ -15,10 +15,10 @@
     "process": "^0.11.10"
   },
   "dependencies": {
-    "@ckb-lumos/base": "next",
-    "@ckb-lumos/bi": "next",
-    "@ckb-lumos/codec": "next",
-    "@ckb-lumos/common-scripts": "next",
+    "@ckb-lumos/base": "canary",
+    "@ckb-lumos/bi": "canary",
+    "@ckb-lumos/codec": "canary",
+    "@ckb-lumos/common-scripts": "canary",
     "@ckb-lumos/lumos": "next",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",

--- a/examples/exchange-sudt-for-ckb/src/lib.ts
+++ b/examples/exchange-sudt-for-ckb/src/lib.ts
@@ -5,7 +5,7 @@ import { payFeeByFeeRate } from "@ckb-lumos/common-scripts/lib/common";
 import { addCellDep } from "@ckb-lumos/common-scripts/lib/helper";
 import { List } from "immutable";
 import { computeScriptHash } from "@ckb-lumos/base/lib/utils";
-import { bytes, number } from "@ckb-lumos/codec";
+import { bytes } from "@ckb-lumos/codec";
 import { blockchain } from "@ckb-lumos/base";
 
 export const { AGGRON4 } = config.predefined;
@@ -122,7 +122,7 @@ export async function transferCKB2SUDT(issuerPrivateKey: string, holderPrivateKe
         break;
       }
       inputs = inputs.push(cell);
-      total = total.add(number.Uint128LE.unpack(cell.data));
+      total = total.add(sudt.unpackAmount(cell.data));
     }
     return inputs;
   });
@@ -146,7 +146,7 @@ export async function transferCKB2SUDT(issuerPrivateKey: string, holderPrivateKe
       lock: holderAccountInfo.lockScript,
       type: issuerTypeScript,
     },
-    data: bytes.hexify(number.Uint128LE.pack(SUDTAmount)),
+    data: sudt.packAmount(SUDTAmount),
   };
 
   console.log(calculateSUDTAmountSum(issuerSUDTCells).toBigInt());
@@ -157,7 +157,7 @@ export async function transferCKB2SUDT(issuerPrivateKey: string, holderPrivateKe
       lock: issuerAccountInfo.lockScript,
       type: issuerTypeScript,
     },
-    data: bytes.hexify(number.Uint128LE.pack(calculateSUDTAmountSum(issuerSUDTCells).sub(SUDTAmount))),
+    data: sudt.packAmount(calculateSUDTAmountSum(issuerSUDTCells).sub(SUDTAmount)),
   };
 
   SUDTTargetOutput.cellOutput.capacity = BI.from(helpers.minimalCellCapacity(SUDTTargetOutput)).toHexString();
@@ -274,7 +274,7 @@ export function calculateSUDTAmountSum(cells: Cell[]) {
   let amount = BI.from(0);
   for (const cell of cells) {
     if (cell.cellOutput.type?.codeHash === AGGRON4.SCRIPTS.SUDT.CODE_HASH) {
-      amount = amount.add(number.Uint128LE.unpack(cell.data));
+      amount = amount.add(sudt.unpackAmount(cell.data));
     }
   }
 
@@ -310,7 +310,7 @@ export async function fetchSUDTBalance(address: string, issuerLockScript: Script
   let amount = BI.from(0);
 
   for await (const cell of collector.collect()) {
-    amount = amount.add(number.Uint128LE.unpack(cell.data));
+    amount = amount.add(sudt.unpackAmount(cell.data));
   }
   return amount;
 }

--- a/packages/ckb-indexer/scripts/e2e-test.ts
+++ b/packages/ckb-indexer/scripts/e2e-test.ts
@@ -48,6 +48,7 @@ async function main() {
 
   ckbProcess.kill();
   indexerProcess.kill();
+  process.exit();
 }
 
 main();

--- a/packages/common-scripts/src/anyone_can_pay.ts
+++ b/packages/common-scripts/src/anyone_can_pay.ts
@@ -13,7 +13,7 @@ import {
   WitnessArgs,
   blockchain,
 } from "@ckb-lumos/base";
-import { bytes, BytesLike, number } from "@ckb-lumos/codec";
+import { bytes } from "@ckb-lumos/codec";
 import { Config, getConfig } from "@ckb-lumos/config-manager";
 import {
   createTransactionFromSkeleton,
@@ -33,12 +33,10 @@ import {
   SECP_SIGNATURE_PLACEHOLDER,
 } from "./helper";
 import { CellCollectorConstructor, CellCollectorType } from "./type";
+import { unpackAmount } from "./sudt";
+
 const { ScriptValue } = values;
 const { CKBHasher, ckbHash } = utils;
-
-function readSudtAmount(data: BytesLike): BI {
-  return number.Uint128LE.unpack(bytes.bytify(data).slice(0, 16));
-}
 
 export const CellCollector: CellCollectorConstructor = class CellCollector
   implements CellCollectorType
@@ -484,7 +482,7 @@ export function prepareSigningEntries(
 
       const sumOfOutputAmount: BI = outputs
         .filter((output) => output.data !== "0x")
-        .map((output) => readSudtAmount(output.data))
+        .map((output) => unpackAmount(output.data))
         .reduce((result, c) => result.add(c), BI.from(0));
 
       const fInputs: List<Cell> = inputs.filter((i) => {
@@ -499,7 +497,7 @@ export function prepareSigningEntries(
 
       const sumOfInputAmount: BI = fInputs
         .filter((i) => i.data !== "0x")
-        .map((i) => BI.from(readSudtAmount(i.data)))
+        .map((i) => BI.from(unpackAmount(i.data)))
         .reduce((result, c) => result.add(c), BI.from(0));
 
       if (

--- a/packages/common-scripts/src/anyone_can_pay.ts
+++ b/packages/common-scripts/src/anyone_can_pay.ts
@@ -13,7 +13,7 @@ import {
   WitnessArgs,
   blockchain,
 } from "@ckb-lumos/base";
-import { bytes, number } from "@ckb-lumos/codec";
+import { bytes, BytesLike, number } from "@ckb-lumos/codec";
 import { Config, getConfig } from "@ckb-lumos/config-manager";
 import {
   createTransactionFromSkeleton,
@@ -35,6 +35,10 @@ import {
 import { CellCollectorConstructor, CellCollectorType } from "./type";
 const { ScriptValue } = values;
 const { CKBHasher, ckbHash } = utils;
+
+function readSudtAmount(data: BytesLike): BI {
+  return number.Uint128LE.unpack(bytes.bytify(data).slice(0, 16));
+}
 
 export const CellCollector: CellCollectorConstructor = class CellCollector
   implements CellCollectorType
@@ -480,7 +484,7 @@ export function prepareSigningEntries(
 
       const sumOfOutputAmount: BI = outputs
         .filter((output) => output.data !== "0x")
-        .map((output) => number.Uint128LE.unpack(output.data))
+        .map((output) => readSudtAmount(output.data))
         .reduce((result, c) => result.add(c), BI.from(0));
 
       const fInputs: List<Cell> = inputs.filter((i) => {
@@ -495,7 +499,7 @@ export function prepareSigningEntries(
 
       const sumOfInputAmount: BI = fInputs
         .filter((i) => i.data !== "0x")
-        .map((i) => BI.from(number.Uint128LE.unpack(i.data)))
+        .map((i) => BI.from(readSudtAmount(i.data)))
         .reduce((result, c) => result.add(c), BI.from(0));
 
       if (

--- a/packages/common-scripts/src/sudt.ts
+++ b/packages/common-scripts/src/sudt.ts
@@ -28,9 +28,13 @@ import anyoneCanPay, {
 const { ScriptValue } = values;
 import secp256k1Blake160 from "./secp256k1_blake160";
 import { BI, BIish } from "@ckb-lumos/bi";
-import { bytes, number } from "@ckb-lumos/codec";
+import { bytes, type BytesLike, number } from "@ckb-lumos/codec";
 
 export type Token = Hash;
+
+function readSudtAmount(data: BytesLike): BI {
+  return number.Uint128LE.unpack(bytes.bytify(data).slice(0, 16));
+}
 
 /**
  * Issue an sUDT cell
@@ -220,7 +224,7 @@ export async function transfer(
     });
 
     toAddressInputCapacity = BI.from(toAddressInput.cellOutput.capacity);
-    toAddressInputAmount = number.Uint128LE.unpack(toAddressInput.data);
+    toAddressInputAmount = readSudtAmount(toAddressInput.data);
   }
 
   const targetOutput: Cell = {
@@ -479,7 +483,7 @@ export async function transfer(
 
       const inputCapacity: BI = BI.from(inputCell.cellOutput.capacity);
       const inputAmount: BI = inputCell.cellOutput.type
-        ? number.Uint128LE.unpack(inputCell.data)
+        ? readSudtAmount(inputCell.data)
         : BI.from(0);
       let deductCapacity: BI =
         isAnyoneCanPay && !destroyable
@@ -601,7 +605,7 @@ export async function transfer(
     if (changeAmount.gt(0)) {
       clonedOutput.data = bytes.hexify(
         number.Uint128LE.pack(
-          number.Uint128LE.unpack(originOutput.data).add(changeAmount)
+          readSudtAmount(originOutput.data).add(changeAmount)
         )
       );
     }

--- a/packages/common-scripts/tests/sudt.test.ts
+++ b/packages/common-scripts/tests/sudt.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./inputs";
 import { BI } from "@ckb-lumos/bi";
 import { bytes, number } from "@ckb-lumos/codec";
+import { packAmount, unpackAmount } from "../src/sudt";
 const { AGGRON4 } = predefined;
 
 test.before(() => {
@@ -662,4 +663,18 @@ test("transfer secp => secp, change to acp and has previous output, split change
 
   const lastOutput = txSkeleton.get("outputs").get(-1)!;
   t.is(lastOutput.cellOutput.type, undefined);
+});
+
+test("pack and unpack sudt amount", (t) => {
+  const unpacked = BI.from(0x1234);
+  const packed = Buffer.alloc(16);
+  // little endian of 0x1234
+  packed.write("3412", "hex");
+
+  t.true(bytes.equal(packAmount(unpacked), packed));
+  t.true(unpackAmount(packed).eq(unpacked));
+
+  const over16Bytes = bytes.concat(packed, packed);
+  t.true(over16Bytes.length > 16);
+  t.true(unpackAmount(over16Bytes).eq(unpacked));
 });


### PR DESCRIPTION
# Description

Fixes #548

the data of an sUDT cell may be over 16 bytes but it is still valid, so we should slice the first 16 bytes as the sUDT amount

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)