### PR TITLE
refactor(base): correct data2 serialization

### DIFF
--- a/packages/base/src/blockchain.ts
+++ b/packages/base/src/blockchain.ts
@@ -103,24 +103,36 @@ export const WitnessArgs = WitnessArgsOf({
 });
 
 /**
+ * <pre>
+ *  0b0000000 0
+ *    ───┬─── │
+ *       │    ▼
+ *       │   type - use the default vm version
+ *       │
+ *       ▼
+ * data* - use a particular vm version
+ * </pre>
+ *
  * Implementation of blockchain.mol
  * https://github.com/nervosnetwork/ckb/blob/5a7efe7a0b720de79ff3761dc6e8424b8d5b22ea/util/types/schemas/blockchain.mol
  */
 export const HashType = createFixedBytesCodec<api.HashType>({
   byteLength: 1,
   pack: (type) => {
-    if (type === "data") return Uint8.pack(0);
-    if (type === "type") return Uint8.pack(1);
-    if (type === "data1") return Uint8.pack(2);
-    if (type === "data2") return Uint8.pack(3);
+    // prettier-ignore
+    if (type === "type")  return Uint8.pack(0b0000000_1);
+    // prettier-ignore
+    if (type === "data")  return Uint8.pack(0b0000000_0);
+    if (type === "data1") return Uint8.pack(0b0000001_0);
+    if (type === "data2") return Uint8.pack(0b0000010_0);
     throw new Error(`Invalid hash type: ${type}`);
   },
   unpack: (buf) => {
     const hashTypeBuf = Uint8.unpack(buf);
-    if (hashTypeBuf === 0) return "data";
-    if (hashTypeBuf === 1) return "type";
-    if (hashTypeBuf === 2) return "data1";
-    if (hashTypeBuf === 3) return "data2";
+    if (hashTypeBuf === 0b0000000_1) return "type";
+    if (hashTypeBuf === 0b0000000_0) return "data";
+    if (hashTypeBuf === 0b0000001_0) return "data1";
+    if (hashTypeBuf === 0b0000010_0) return "data2";
     throw new Error(`Invalid hash type: ${hashTypeBuf}`);
   },
 });

--- a/packages/base/tests/serialize.test.ts
+++ b/packages/base/tests/serialize.test.ts
@@ -41,7 +41,7 @@ test("serialize ckb2023 script", (t) => {
   const serializedHex = bytes.hexify(blockchain.Script.pack(value));
   t.deepEqual(
     serializedHex,
-    "0x3d0000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce80308000000aabbccdd44332211"
+    "0x3d0000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce80408000000aabbccdd44332211"
   );
 });
 

--- a/packages/ckb-indexer/scripts/e2e-test.ts
+++ b/packages/ckb-indexer/scripts/e2e-test.ts
@@ -48,6 +48,7 @@ async function main() {
 
   ckbProcess.kill();
   indexerProcess.kill();
+  process.exit();
 }
 
 main();

--- a/packages/e2e-test/scripts/run.ts
+++ b/packages/e2e-test/scripts/run.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { mkdirSync, rmSync } from "node:fs";
 import { retry } from "@ckb-lumos/utils";
 import { RPC } from "@ckb-lumos/rpc";
-import { LightClientRPC } from "@ckb-lumos/light-client";
+// import { LightClientRPC } from "@ckb-lumos/light-client";
 import killPort from "kill-port";
 import {
   ckb,
@@ -15,7 +15,7 @@ import {
   CKB_RPC_PORT,
   CKB_RPC_URL,
   LIGHT_CLIENT_RPC_PORT,
-  LIGHT_CLIENT_RPC_URL,
+  // LIGHT_CLIENT_RPC_URL,
 } from "../src/constants";
 
 const MODULE_PATH = join(__dirname, "..");
@@ -36,7 +36,7 @@ async function main() {
   mkdirSync(CKB_CWD, { recursive: true });
   mkdirSync(LIGHT_CLIENT_CWD, { recursive: true });
 
-  const ckbReleaseUrl = ckb.getReleaseUrl({ version: "v0.111.0-rc1" });
+  const ckbReleaseUrl = ckb.getReleaseUrl({ version: "v0.111.0" });
   const ckbDownloadDest = getDefaultDownloadDestination(ckbReleaseUrl);
   let ckbBinaryPath = ckb.findBinaryPath(ckbDownloadDest);
 
@@ -102,34 +102,37 @@ async function main() {
     cwd: LIGHT_CLIENT_CWD,
   });
 
-  const lightClientProcess = spawn(
-    lightClientBinaryPath,
-    ["run", "--config-file", join(LIGHT_CLIENT_CWD, "light-client.toml")],
-    {
-      stdio: "inherit",
-      cwd: LIGHT_CLIENT_CWD,
-      env: {
-        RUST_LOG: "info",
-        ckb_light_client: "info",
-      },
-    }
-  );
+  // TODO uncomment me when the light client is available for CKB2023
+  // const lightClientProcess = spawn(
+  //   lightClientBinaryPath,
+  //   ["run", "--config-file", join(LIGHT_CLIENT_CWD, "light-client.toml")],
+  //   {
+  //     stdio: "inherit",
+  //     cwd: LIGHT_CLIENT_CWD,
+  //     env: {
+  //       RUST_LOG: "info",
+  //       ckb_light_client: "info",
+  //     },
+  //   }
+  // );
 
-  const lightClientRpc = new LightClientRPC(LIGHT_CLIENT_RPC_URL);
-  const lightClientTip = await retry(() => lightClientRpc.getTipHeader(), {
-    retries: 30,
-    timeout: 30_000,
-    delay: 100,
-  });
+  // const lightClientRpc = new LightClientRPC(LIGHT_CLIENT_RPC_URL);
+  // const lightClientTip = await retry(() => lightClientRpc.getTipHeader(), {
+  //   retries: 30,
+  //   timeout: 30_000,
+  //   delay: 100,
+  // });
 
-  console.info("Light Client started, tip header:", lightClientTip);
+  // console.info("Light Client started, tip header:", lightClientTip);
 
-  execSync("npx ava '**/*.e2e.test.ts' --verbose --timeout=5m", {
+  // TODO uncomment me when the light client is available for CKB2023
+  // execSync("npx ava '**/*.e2e.test.ts' --verbose --timeout=5m", {
+  execSync("npx ava '**/{rpc,indexer}.e2e.test.ts' --verbose --timeout=5m", {
     cwd: pathTo("/"),
     stdio: "inherit",
   });
 
-  lightClientProcess.kill();
+  // lightClientProcess.kill();
   ckbMinerProcess.kill();
   ckbProcess.kill();
 

--- a/packages/testkit/src/ckb-indexer-helper.ts
+++ b/packages/testkit/src/ckb-indexer-helper.ts
@@ -3,6 +3,7 @@ import compareVersions from "compare-versions";
 import os from "os";
 // TODO dep
 import downloadAndExtract from "download";
+import childProcess from "node:child_process";
 
 function log(info: string): void {
   console.log(info);
@@ -85,10 +86,7 @@ export async function startCKBIndexer(CKBVersion?: string): Promise<void> {
   await downloadCKBIndexer();
   console.log("start indexer at", new Date().toLocaleString());
 
-  shell.exec(
-    `RUST_LOG=info ./ckb-indexer -c http://127.0.0.1:8118/rpc -l 127.0.0.1:8120 -s indexer-store-tmp`,
-    {
-      async: true,
-    }
+  childProcess.exec(
+    `RUST_LOG=info ./ckb-indexer -c http://127.0.0.1:8118/rpc -l 127.0.0.1:8120 -s indexer-store-tmp`
   );
 }


### PR DESCRIPTION
# Description

Fixes #551 

This PR has 

- updated the serialization of the `data2`
- skipped the e2e test for the light client because the light client is unavailable for CKB2023 now
- upgraded the CKB node in the e2e test to v0.111.0

# How Has This Been Tested?

<!--  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [x] Modified `data2` unit test
