### PR TITLE
feat(rpc): added `unknown | rejected` to `TxStatus`

### DIFF
--- a/.changeset/old-houses-smell.md
+++ b/.changeset/old-houses-smell.md
@@ -1,0 +1,5 @@
+---
+"@ckb-lumos/rpc": minor
+---
+
+`unknown` and `rejected` are available in the `TransactionWithStatus`

--- a/packages/rpc/src/types/rpc.ts
+++ b/packages/rpc/src/types/rpc.ts
@@ -43,6 +43,8 @@ export namespace RPC {
     Pending = "pending",
     Proposed = "proposed",
     Committed = "committed",
+    Unknown = "unknown",
+    Rejected = "rejected",
   }
 
   export type DepType = "code" | "dep_group";
@@ -118,7 +120,11 @@ export namespace RPC {
         }
       | {
           block_hash: undefined;
-          status: TransactionStatus.Pending | TransactionStatus.Proposed;
+          status:
+            | TransactionStatus.Pending
+            | TransactionStatus.Proposed
+            | TransactionStatus.Rejected
+            | TransactionStatus.Unknown;
         };
     time_added_to_pool: Uint64 | null;
     cycles: Uint64 | null;


### PR DESCRIPTION
# Description

Make `unknown` and `rejected` be available in `TransactionStatus`

https://github.com/nervosnetwork/ckb/blob/922516e967df45c08ce4a62f4c3f2fd8db88d745/util/jsonrpc-types/src/blockchain.rs#L580-L583

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
