### PR TITLE
fix(utils): stop immediately when retry limited

### DIFF
--- a/packages/utils/src/async/index.ts
+++ b/packages/utils/src/async/index.ts
@@ -86,12 +86,12 @@ export function retry<T>(
 
   const retryPromise = new Promise<T>((resolve, reject) => {
     function handleError(err: unknown) {
-      currentRetryTimes++;
-
-      if (currentRetryTimes >= retries) {
+      if (currentRetryTimes > retries) {
         reject(err);
         return;
       }
+
+      currentRetryTimes++;
 
       if (delayMs) {
         delay(delayMs).then(retryRun);


### PR DESCRIPTION
# Description

This PR makes the e2e test stop immediately after the retry limited instead of waiting until the timeout

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
