### PR TITLE
perf(codec): improve bytify and hexify perf

### DIFF
--- a/.changeset/big-ears-allow.md
+++ b/.changeset/big-ears-allow.md
@@ -1,0 +1,5 @@
+---
+"@ckb-lumos/codec": patch
+---
+
+improving `hexify` and `bytify` performance

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "ava": "^3.8.2",
+    "benchmark": "^2.1.4",
     "c8": "^7.10.0",
     "eslint": "^8.40.0",
     "eslint-import-resolver-typescript": "^2.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -56,6 +56,9 @@ importers:
       ava:
         specifier: ^3.8.2
         version: 3.8.2
+      benchmark:
+        specifier: ^2.1.4
+        version: 2.1.4
       c8:
         specifier: ^7.10.0
         version: 7.10.0
@@ -7363,6 +7366,13 @@ packages:
     resolution: {integrity: sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==}
     dev: false
 
+  /benchmark@2.1.4:
+    resolution: {integrity: sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==}
+    dependencies:
+      lodash: 4.17.21
+      platform: 1.3.6
+    dev: true
+
   /better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -14366,6 +14376,10 @@ packages:
     dependencies:
       find-up: 3.0.0
     dev: false
+
+  /platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+    dev: true
 
   /plur@4.0.0:
     resolution: {integrity: sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==}


### PR DESCRIPTION
# Description

A performance issue was found in #579 

## Type of change

- [x] Refactor (non-breaking change)

# How Has This Been Tested?

<details>
<summary>benchmark.js</summary>

```js
import Benchmark from "benchmark";
import { randomBytes } from "node:crypto";
import bytesOld from "./lib/bytes.js";
import bytesNew from "./lib/bytes-new.js";

const bytesData = randomBytes(10000);
const hexData = bytesNew.hexify(bytesData);

const suite = Benchmark.Suite();

suite
  .add("hexify-old", () => {
    bytesOld.hexify(bytesData);
  })
  .add("hexify-new", () => {
    bytesNew.hexify(bytesData);
  })
  .add("bytify-old", () => {
    bytesOld.bytify(hexData);
  })
  .add("bytify-new", () => {
    bytesNew.bytify(hexData);
  })
  .on("cycle", (event) => {
    console.log(String(event.target));
  })
  .run();
```

</details>

```
➜  codec git:(perf-bytes) ✗ bun run bench.mjs
hexify-old x 1,328 ops/sec ±0.38% (95 runs sampled)
hexify-new x 4,606 ops/sec ±0.33% (95 runs sampled)
bytify-old x 1,192 ops/sec ±0.51% (95 runs sampled)
bytify-new x 4,597 ops/sec ±0.29% (96 runs sampled)
➜  codec git:(perf-bytes) ✗ clear
➜  codec git:(perf-bytes) ✗ bun run bench.mjs
hexify-old x 1,325 ops/sec ±0.36% (95 runs sampled)
hexify-new x 4,524 ops/sec ±0.30% (97 runs sampled)
bytify-old x 1,184 ops/sec ±0.42% (96 runs sampled)
bytify-new x 4,547 ops/sec ±0.31% (95 runs sampled)
➜  codec git:(perf-bytes) ✗ node bench.mjs
hexify-old x 2,079 ops/sec ±0.75% (96 runs sampled)
hexify-new x 21,727 ops/sec ±1.01% (93 runs sampled)
bytify-old x 2,320 ops/sec ±0.29% (97 runs sampled)
bytify-new x 2,440 ops/sec ±0.38% (98 runs sampled)
➜  codec git:(perf-bytes) ✗ node bench.mjs
hexify-old x 2,092 ops/sec ±0.74% (93 runs sampled)
hexify-new x 22,277 ops/sec ±0.49% (99 runs sampled)
bytify-old x 2,319 ops/sec ±0.39% (97 runs sampled)
bytify-new x 2,467 ops/sec ±0.17% (99 runs sampled)
➜  codec git:(perf-bytes) ✗ node --version
v21.3.0
➜  codec git:(perf-bytes) ✗ bun --version    
1.0.15
```

<!-- 
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules -->