### PR TITLE
fix(rpc): abort-controller is not a constructor in browsers

### DIFF
--- a/.changeset/tough-jobs-decide.md
+++ b/.changeset/tough-jobs-decide.md
@@ -1,0 +1,5 @@
+---
+"@ckb-lumos/rpc": patch
+---
+
+fix: `_abortController.AbortController` is not a constructor in browser

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from "./exceptions";
 import { RPCConfig } from "./types/common";
 import fetch_ from "cross-fetch";
-import { AbortController as CrossAbortController } from "abort-controller";
+import AbortController from "abort-controller";
 
 export const ParamsFormatter = paramsFormatter;
 export const ResultFormatter = resultFormatter;
@@ -134,8 +134,8 @@ export class CKBRPC extends Base {
             }
           });
 
-          const controller = new CrossAbortController() as AbortController;
-          const signal = controller.signal;
+          const controller = new AbortController();
+          const signal = controller.signal as AbortSignal;
 
           const timeout = setTimeout(
             () => controller.abort(),
@@ -147,7 +147,7 @@ export class CKBRPC extends Base {
               method: "POST",
               headers: { "content-type": "application/json" },
               body: JSON.stringify(payload),
-              signal: signal,
+              signal,
             })
             .then((res) => res.json());
 

--- a/packages/rpc/src/method.ts
+++ b/packages/rpc/src/method.ts
@@ -1,7 +1,7 @@
 import { IdNotMatchException, ResponseException } from "./exceptions";
 import { CKBComponents } from "./types/api";
 import { RPCConfig } from "./types/common";
-import { AbortController as CrossAbortController } from "abort-controller";
+import AbortController from "abort-controller";
 import fetch_ from "cross-fetch";
 
 export class Method {
@@ -42,8 +42,8 @@ export class Method {
   /* eslint-disable @typescript-eslint/ban-types, @typescript-eslint/explicit-module-boundary-types */
   public call = async (...params: (string | number | object)[]) => {
     const payload = this.getPayload(...params);
-    const controller = new CrossAbortController() as AbortController;
-    const signal = controller.signal;
+    const controller = new AbortController();
+    const signal = controller.signal as AbortSignal;
 
     const timeout = setTimeout(() => controller.abort(), this.#config.timeout);
 


### PR DESCRIPTION
# Description

This PR fixes `_abortController.AbortController is not a constructor` while running lumos in browsers because the `export` behavior in `abort-controller` is not the same between `browser` and `node`.

## Related pieces

- https://github.com/mysticatea/abort-controller/blob/a935d38e09eb95d6b633a8c42fcceec9969e7b05/browser.js#L11-L13
- https://github.com/mysticatea/abort-controller/blob/a935d38e09eb95d6b633a8c42fcceec9969e7b05/src/abort-controller.ts#L63
- https://github.com/mysticatea/abort-controller/pull/22

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```sh
git clone https://github.com/ckb-js/lumos.git
cd lumos
git checkout abort-controller-not-found
pnpm install
npm run clean
npm run build
cd examples/omni-lock-secp256k1-blake160
pnpm install
npm start
```