### PR TITLE
feat(codec): supported union with custom id

### DIFF
--- a/.changeset/fluffy-rabbits-tell.md
+++ b/.changeset/fluffy-rabbits-tell.md
@@ -1,0 +1,5 @@
+---
+"@ckb-lumos/molecule": minor
+---
+
+feat: supported union with custom id

--- a/.changeset/fluffy-rabbits-tell.md
+++ b/.changeset/fluffy-rabbits-tell.md
@@ -1,5 +1,6 @@
 ---
 "@ckb-lumos/molecule": minor
+"@ckb-lumos/codec": minor
 ---
 
-feat: supported union with custom id
+feat: supported union works with custom id

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,28 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "@ckb-lumos/base": "0.21.1",
+    "@ckb-lumos/bi": "0.21.1",
+    "@ckb-lumos/ckb-indexer": "0.21.1",
+    "@ckb-lumos/codec": "0.21.1",
+    "@ckb-lumos/common-scripts": "0.21.1",
+    "@ckb-lumos/config-manager": "0.21.1",
+    "@ckb-lumos/debugger": "0.21.1",
+    "@ckb-lumos/e2e-test": "0.21.1",
+    "@ckb-lumos/experiment-tx-assembler": "0.21.1",
+    "@ckb-lumos/hd": "0.21.1",
+    "@ckb-lumos/hd-cache": "0.21.1",
+    "@ckb-lumos/helpers": "0.21.1",
+    "@ckb-lumos/light-client": "0.21.1",
+    "@ckb-lumos/lumos": "0.21.1",
+    "@ckb-lumos/molecule": "0.21.1",
+    "@ckb-lumos/rpc": "0.21.1",
+    "@ckb-lumos/runner": "0.21.1",
+    "@ckb-lumos/testkit": "0.21.1",
+    "@ckb-lumos/toolkit": "0.21.1",
+    "@ckb-lumos/transaction-manager": "0.21.1",
+    "@ckb-lumos/utils": "0.21.1"
+  },
+  "changesets": []
+}

--- a/.changeset/tender-apes-speak.md
+++ b/.changeset/tender-apes-speak.md
@@ -1,0 +1,5 @@
+---
+"@ckb-lumos/codec": minor
+---
+
+feat: supported custom union id in union

--- a/.changeset/tender-apes-speak.md
+++ b/.changeset/tender-apes-speak.md
@@ -1,5 +1,0 @@
----
-"@ckb-lumos/codec": minor
----
-
-feat: supported custom union id in union

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -22,6 +22,7 @@ const scopeEnumValues = [
   "utils",
   "runner",
   "e2e-test",
+  "molecule",
 ];
 const Configuration = {
   extends: ["@commitlint/config-conventional"],

--- a/packages/codec/src/molecule/layout.ts
+++ b/packages/codec/src/molecule/layout.ts
@@ -338,6 +338,14 @@ export function union<T extends Record<string, BytesCodec>>(
 ): UnionCodec<T> {
   checkShape(itemCodec, Array.isArray(fields) ? fields : Object.keys(fields));
 
+  // check duplicated id
+  if (!Array.isArray(fields)) {
+    const ids = Object.values(fields);
+    if (ids.length !== new Set(ids).size) {
+      throw new Error(`Duplicated id in union: ${ids.join(", ")}`);
+    }
+  }
+
   return createBytesCodec({
     pack(obj) {
       const availableFields: (keyof T)[] = Object.keys(itemCodec);

--- a/packages/codec/tests/molecule.test.ts
+++ b/packages/codec/tests/molecule.test.ts
@@ -222,6 +222,11 @@ test("test union with custom id", (t) => {
 
   // @ts-expect-error
   t.throws(() => union({ key1: Uint8, key2: Uint32LE }, { unknown: 0x1 }));
+  // prettier-ignore
+  t.throws(() => codec.unpack([
+    0x00, 0x00, 0x00, 0x00, // unknown key
+    0x11,
+  ]));
 });
 
 test("test byteOf", (t) => {

--- a/packages/codec/tests/molecule.test.ts
+++ b/packages/codec/tests/molecule.test.ts
@@ -229,6 +229,10 @@ test("test union with custom id", (t) => {
   ]));
 });
 
+test("test union with duplicated custom id", (t) => {
+  t.throws(() => union({ key1: Uint8, key2: Uint32LE }, { key1: 0, key2: 0 }));
+});
+
 test("test byteOf", (t) => {
   t.deepEqual(byteOf(Uint8).pack(1), bytify([1]));
   t.throws(() => byteOf(Uint16).pack(1));

--- a/packages/codec/tests/molecule.test.ts
+++ b/packages/codec/tests/molecule.test.ts
@@ -12,7 +12,7 @@ import {
 import { Bytes, createFixedHexBytesCodec } from "../src/blockchain";
 import { bytify } from "../src/bytes";
 import test, { ExecutionContext } from "ava";
-import { Uint16, Uint16BE, Uint32, Uint8 } from "../src/number";
+import { Uint16, Uint16BE, Uint32, Uint32LE, Uint8 } from "../src/number";
 import { byteOf } from "../src/molecule";
 import { CodecExecuteError } from "../src/error";
 
@@ -193,6 +193,37 @@ test("test layout-union", (t) => {
   t.throws(() => codec.pack({ type: "unknown", value: [] }));
 });
 
+test("test union with custom id", (t) => {
+  const codec = union(
+    { key1: Uint8, key2: Uint32LE },
+    { key1: 0xaa, key2: 0xbb }
+  );
+
+  // prettier-ignore
+  const case1 = bytify([
+    0xaa, 0x00, 0x00, 0x00, // key1
+    0x11, // value
+  ]);
+
+  t.deepEqual(codec.unpack(case1), { type: "key1", value: 0x11 });
+  t.deepEqual(codec.pack({ type: "key1", value: 0x11 }), case1);
+
+  // prettier-ignore
+  const case2 = bytify([
+    0xbb, 0x00, 0x00, 0x00, // key2
+    0x00, 0x00, 0x00, 0x11, // value u32le
+  ])
+
+  t.deepEqual(codec.unpack(case2), { type: "key2", value: 0x11_00_00_00 });
+  t.deepEqual(codec.pack({ type: "key2", value: 0x11_00_00_00 }), case2);
+
+  // @ts-expect-error
+  t.throws(() => codec.pack({ type: "unknown", value: 0x11 }));
+
+  // @ts-expect-error
+  t.throws(() => union({ key1: Uint8, key2: Uint32LE }, { unknown: 0x1 }));
+});
+
 test("test byteOf", (t) => {
   t.deepEqual(byteOf(Uint8).pack(1), bytify([1]));
   t.throws(() => byteOf(Uint16).pack(1));
@@ -316,7 +347,7 @@ test("nested type", (t) => {
     ["byteField", "arrayField", "structField", "fixedVec", "dynVec", "option"]
   );
 
-  const validInput: Parameters<typeof codec["pack"]>[0] = {
+  const validInput: Parameters<(typeof codec)["pack"]>[0] = {
     byteField: 0x1,
     arrayField: [0x2, 0x3, 0x4],
     structField: { f1: 0x5, f2: 0x6 },

--- a/packages/molecule/README.md
+++ b/packages/molecule/README.md
@@ -1,0 +1,14 @@
+# @ckb-lumos/molecule
+
+A molecule parser written in JavaScript that helps developers to parse molecule into a codec map.
+
+```js
+const { createParser } = require("@ckb-lumos/molecule");
+
+const parser = createParser();
+const codecMap = parser.parse(`
+  array Uint8 [byte; 1];
+`);
+
+codecMap.Uint8.pack(1);
+```

--- a/packages/molecule/src/grammar/mol.js
+++ b/packages/molecule/src/grammar/mol.js
@@ -229,11 +229,25 @@
         },
       },
       {
+        name: "union_item_decl",
+        symbols: ["identifier", "_", { literal: ":" }, "_", "number"],
+        postprocess: function (data) {
+          return [data[0].value, Number(data[4].value)];
+        },
+      },
+      {
+        name: "union_item_decl",
+        symbols: ["identifier"],
+        postprocess: function (data) {
+          return data[0].value;
+        },
+      },
+      {
         name: "union_definition$ebnf$1$subexpression$1",
         symbols: [
           "multi_line_ws_char",
           "_",
-          "identifier",
+          "union_item_decl",
           "_",
           "comma",
           "_",
@@ -251,7 +265,7 @@
         symbols: [
           "multi_line_ws_char",
           "_",
-          "identifier",
+          "union_item_decl",
           "_",
           "comma",
           "_",
@@ -287,7 +301,7 @@
           return {
             type: "union",
             name: data[2].value,
-            items: data[6].map((d) => d[2].value),
+            items: data[6].map((d) => d[2]),
           };
         },
       },

--- a/packages/molecule/src/grammar/mol.ne
+++ b/packages/molecule/src/grammar/mol.ne
@@ -117,20 +117,20 @@ top_level_statement
 
 array_definition
     -> "array" __ identifier _ lbracket _ identifier _ semicolon _ number _ rbracket _ semicolon _ comment_opt
-        {% 
+        {%
             function(data) {
                 return {
                     type: "array",
                     name: data[2].value,
                     item:  data[6].value,
-                    item_count: data[10].value 
+                    item_count: data[10].value
                 };
             }
         %}
 
 vector_definition
      -> "vector" __ identifier _ labracket _ identifier _ rabracket _ semicolon _ comment_opt
-        {% 
+        {%
             function(data) {
                 return {
                     type: "vector",
@@ -142,7 +142,7 @@ vector_definition
 
 option_definition
      -> "option" __ identifier _ lparan _ identifier _ rparan _ semicolon _ comment_opt
-        {% 
+        {%
             function(data) {
                 return {
                     type: "option",
@@ -152,21 +152,35 @@ option_definition
             }
         %}
 
+union_item_decl
+     -> identifier _ ":" _ number
+     {%
+        function (data) {
+            return [data[0].value, Number(data[4].value)]
+        }
+     %}
+     | identifier
+     {%
+        function (data) {
+            return data[0].value
+        }
+    %}
+
 union_definition
-     -> "union" __ identifier _ lbrace _ (multi_line_ws_char _ identifier _ comma _ comment_opt _ multi_line_ws_char):+  _ rbrace
-        {% 
+     -> "union" __ identifier _ lbrace _ (multi_line_ws_char _ union_item_decl _ comma _ comment_opt _ multi_line_ws_char):+  _ rbrace
+        {%
             function(data) {
                 return {
                     type: "union",
                     name: data[2].value,
-                    items:  data[6].map(d => d[2].value),
+                    items:  data[6].map(d => d[2]),
                 };
             }
         %}
 
 struct_definition
      -> "struct" __ identifier _ block_definition
-        {% 
+        {%
             function(data) {
                 return {
                     type: "struct",
@@ -178,7 +192,7 @@ struct_definition
 
 table_definition
      -> "table" __ identifier _ block_definition
-        {% 
+        {%
             function(data) {
                 return {
                     type: "table",

--- a/packages/molecule/src/nearley.ts
+++ b/packages/molecule/src/nearley.ts
@@ -13,6 +13,7 @@ import {
   ParseOptions,
 } from "./type";
 import { nonNull, toMolTypeMap } from "./utils";
+import { Uint32 } from "@ckb-lumos/codec/lib/number";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const grammar = require("./grammar/mol.js");
@@ -92,9 +93,15 @@ export const checkDependencies = (results: MolType[]): void => {
       }
       case "union": {
         const unionDeps = (molItem as Union).items;
-        unionDeps.forEach((dep: string) => {
-          if (dep !== byte) {
+        unionDeps.forEach((dep) => {
+          if (typeof dep === "string" && dep !== byte) {
             nonNull(map[dep]);
+          }
+          if (Array.isArray(dep)) {
+            const [key, id] = dep;
+            // check if the id is a valid uint32
+            Uint32.pack(id);
+            nonNull(map[key]);
           }
         });
         break;

--- a/packages/molecule/src/type.ts
+++ b/packages/molecule/src/type.ts
@@ -27,7 +27,7 @@ export type Option = {
 export type Union = {
   type: "union";
   name: string;
-  items: string[];
+  items: (string | [string, number])[];
 };
 
 export type Struct = {

--- a/packages/molecule/tests/codec.test.ts
+++ b/packages/molecule/tests/codec.test.ts
@@ -525,3 +525,28 @@ test("should unpack only one WitnessArgs", (t) => {
     }
   );
 });
+
+test("checkDependencies should work correctly with union", (t) => {
+  checkDependencies([
+    { type: "array", name: "Uint8", item: "byte", item_count: 1 },
+    { type: "array", name: "Uint16", item: "byte", item_count: 2 },
+    { type: "array", name: "Uint32", item: "byte", item_count: 4 },
+
+    // without custom id
+    { type: "union", name: "Test1", items: ["Uint8", "Uint16", "Uint32"] },
+    // prettier-ignore
+    // with custom id
+    { type: "union", name: "Test2", items: [["Uint8", 111], ["Uint16", 222], ["Uint32", 333]] },
+  ]);
+
+  t.pass();
+});
+
+test("checkDependencies should throw when id is larger than uint32", (t) => {
+  t.throws(() =>
+    checkDependencies([
+      { type: "array", name: "Uint8", item: "byte", item_count: 1 },
+      { type: "union", name: "Test", items: [["Uint8", 0xff_ff_ff_ff + 1]] },
+    ])
+  );
+});

--- a/packages/molecule/tests/grammar.test.ts
+++ b/packages/molecule/tests/grammar.test.ts
@@ -45,6 +45,51 @@ test("should parse sample with refs", (t) => {
   );
 });
 
+test("union with custom id", (t) => {
+  const parser = createParser();
+  const withCustomId = parser.parse(`
+    array Uint8 [byte; 1];
+    array Uint16 [byte; 2];
+    array Uint32 [byte; 4];
+    
+    union JSNumber {
+      Uint8: 8,
+      Uint16: 16,
+      Uint32: 32,
+    }
+  `);
+
+  t.deepEqual(
+    withCustomId.JSNumber.pack({ type: "Uint8", value: 1 }),
+    // prettier-ignore
+    Uint8Array.from([
+      0x08, 0x00, 0x00, 0x00, // id should be 8
+      0x01
+    ])
+  );
+
+  const withoutCustomId = parser.parse(`
+    array Uint8 [byte; 1];
+    array Uint16 [byte; 2];
+    array Uint32 [byte; 4];
+    
+    union JSNumber {
+      Uint8,
+      Uint16,
+      Uint32,
+    }
+  `);
+
+  t.deepEqual(
+    withoutCustomId.JSNumber.pack({ type: "Uint8", value: 1 }),
+    // prettier-ignore
+    Uint8Array.from([
+      0x00, 0x00, 0x00, 0x00, // id should be 0
+      0x01
+    ])
+  );
+});
+
 test("should parse blockchain.mol", (t) => {
   const parser = createParser();
   // https://github.com/nervosnetwork/ckb/blob/5a7efe7a0b720de79ff3761dc6e8424b8d5b22ea/util/types/schemas/blockchain.mol


### PR DESCRIPTION
# Description

Fixes #584 

This PR supported `molecule.union` with a custom id

```ts
const Bee = Uint8
const Cafe = Uint16

const codec = union(
  { Bee, Cafe },
  { Bee: 0xBee, Cafe: 0xCafe }, // custom id
)
```

You can try the feature on the preview [website](https://lumos-website-git-custom-union-id-magickbase.vercel.app/)

<img width="839" alt="image" src="https://github.com/ckb-js/lumos/assets/7511174/6dad462d-ff8d-4c0f-b49d-3846ca01e4ad">


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

- [x] Unit tests
