### PR TITLE
fix(rpc): get_live_cell should be nullable

### DIFF
--- a/.changeset/kind-chefs-sniff.md
+++ b/.changeset/kind-chefs-sniff.md
@@ -1,0 +1,5 @@
+---
+"@ckb-lumos/rpc": minor
+---
+
+fix: `getLiveCell` should be nullable

--- a/packages/rpc/src/Base/index.ts
+++ b/packages/rpc/src/Base/index.ts
@@ -130,7 +130,7 @@ export interface Base {
     outPoint: CKBComponents.OutPoint,
     withData: boolean
   ) => Promise<{
-    cell: CKBComponents.LiveCell;
+    cell: Option<CKBComponents.LiveCell>;
     status: CKBComponents.CellStatus;
   }>;
 
@@ -543,3 +543,5 @@ export class Base {
     return this.#rpcProperties;
   }
 }
+
+export type Option<T> = T | null;


### PR DESCRIPTION
# Description

[`get_live_cell` should be nullable](https://github.com/nervosnetwork/ckb/blob/0c33675e11ec072fbbe41c135a88749167f204d0/util/jsonrpc-types/src/cell.rs#L49) to force checking the `cell` field at compile time when using TypeScript

```ts
TypeError: Cannot read properties of null (reading 'output')
     28|   const liveCell = await props.rpc.getLiveCell(props.outPoint, true);
     29|   const cell: Cell = {
     30|     cellOutput: liveCell.cell.output,
       |                               ^
     31|     data: liveCell.cell.data.content,
     32|     outPoint: props.outPoint,
```

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

