### PR TITLE
feat(config-manager): upgrade testnet omnilock config

### DIFF
--- a/.changeset/spicy-chefs-marry.md
+++ b/.changeset/spicy-chefs-marry.md
@@ -1,0 +1,5 @@
+---
+"@ckb-lumos/config-manager": minor
+---
+
+feat: update testnet omnilock config

--- a/packages/config-manager/src/predefined.ts
+++ b/packages/config-manager/src/predefined.ts
@@ -133,7 +133,7 @@ const AGGRON4 = createConfig({
         "0xf329effd1c475a2978453c8600e1eaf0bc2087ee093c3ee64cc96ec6847752cb",
       HASH_TYPE: "type",
       TX_HASH:
-        "0x27b62d8be8ed80b9f56ee0fe41355becdb6f6a40aeba82d3900434f43b1c8b60",
+        "0xff234bf2fb0ad2ab5b356ceda317d3dee3efb2c55b9427ef55d9dcbf6eecbf9f",
       INDEX: "0x0",
       DEP_TYPE: "code",
     },


### PR DESCRIPTION
# Description

The testnet Omnilock is upgraded 

before: https://pudge.explorer.nervos.org/transaction/0x27b62d8be8ed80b9f56ee0fe41355becdb6f6a40aeba82d3900434f43b1c8b60#0
after: https://pudge.explorer.nervos.org/transaction/0xff234bf2fb0ad2ab5b356ceda317d3dee3efb2c55b9427ef55d9dcbf6eecbf9f#0

## Type of change

- [x] New feature (non-breaking change which adds functionality)
