### PR TITLE
feat: deprecate config/helpers and fix website address conversion

### DIFF
--- a/.changeset/wild-dodos-notice.md
+++ b/.changeset/wild-dodos-notice.md
@@ -1,0 +1,6 @@
+---
+"@ckb-lumos/config-manager": minor
+"@ckb-lumos/lumos": minor
+---
+
+feat: **deprecated** the `helpers` in `config-manager` to avoid confused with `@ckb-lumos/helpers`

--- a/packages/config-manager/src/index.ts
+++ b/packages/config-manager/src/index.ts
@@ -1,5 +1,9 @@
 export * from "./types";
 export { initializeConfig, getConfig, validateConfig } from "./manager";
+/**
+ * @deprecated use the {@link nameOfScript} and {@link findConfigByScript} function instead
+ */
 export * as helpers from "./helpers";
+export { nameOfScript, findConfigByScript } from "./helpers";
 export { predefined, createConfig } from "./predefined";
 export { generateGenesisScriptConfigs } from "./genesis";

--- a/packages/lumos/src/config.ts
+++ b/packages/lumos/src/config.ts
@@ -16,4 +16,13 @@ export {
   validateConfig,
   initializeConfig,
   getConfig,
+  /**
+   * @deprecated use the {@link nameOfScript} and {@link findConfigByScript} function instead
+   */
+  helpers,
 } from "@ckb-lumos/config-manager";
+
+export {
+  nameOfScript,
+  findConfigByScript,
+} from "@ckb-lumos/config-manager/lib/helpers";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -753,6 +753,9 @@ importers:
 
   website:
     dependencies:
+      '@ckb-lumos/helpers':
+        specifier: canary
+        version: link:../packages/helpers
       '@ckb-lumos/lumos':
         specifier: canary
         version: link:../packages/lumos

--- a/website/package.json
+++ b/website/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@ckb-lumos/lumos": "canary",
+    "@ckb-lumos/helpers": "canary",
     "@ckb-lumos/molecule": "canary",
     "@docusaurus/core": "^3.0.0",
     "@docusaurus/preset-classic": "^3.0.0",

--- a/website/src/components/address-conversion/parseMultiVersionAddress.ts
+++ b/website/src/components/address-conversion/parseMultiVersionAddress.ts
@@ -1,42 +1,37 @@
-import { config as lumosConfig, helpers, Script } from "@ckb-lumos/lumos";
-import { Err, MultiVersionAddress } from "@site/src/types";
+import { config as lumosConfig, Script } from "@ckb-lumos/lumos"
+import * as helpers from "@ckb-lumos/helpers"
+import { Err, MultiVersionAddress } from "@site/src/types"
 
-export type ParseResult = MultiVersionAddress | Err;
+export type ParseResult = MultiVersionAddress | Err
 
-export function parseMultiVersionAddress(
-  script: Script,
-  config: lumosConfig.Config
-): ParseResult {
+export function parseMultiVersionAddress(script: Script, config: lumosConfig.Config): ParseResult {
   try {
-    const name = lumosConfig.helpers.nameOfScript(script, config.SCRIPTS) as
-      | string
-      | undefined;
-    const ckb2021 = helpers.encodeToAddress(script, { config });
+    const name = lumosConfig.helpers.nameOfScript(script, config.SCRIPTS) as string | undefined
+    const ckb2021 = helpers.encodeToAddress(script, { config })
 
-    if (script.hashType === "data1" || script.hashType === 'data2') {
+    if (script.hashType === "data1" || script.hashType === "data2") {
       return {
         name,
         script,
         ckb2019FullFormat: undefined,
         ckb2019ShortFormat: undefined,
         ckb2021FullFormat: ckb2021,
-      };
+      }
     }
 
     const ckb2019Full = helpers.generateAddress(script, {
       config: { SCRIPTS: {}, PREFIX: config.PREFIX },
-    });
-    const ckb2019Short = helpers.generateAddress(script, { config });
+    })
+    const ckb2019Short = helpers.generateAddress(script, { config })
 
     return {
       script,
       name,
       ckb2019FullFormat: ckb2019Full,
-      ckb2019ShortFormat:
-        ckb2019Short === ckb2019Full ? undefined : ckb2019Short,
+      ckb2019ShortFormat: ckb2019Short === ckb2019Full ? undefined : ckb2019Short,
       ckb2021FullFormat: helpers.encodeToAddress(script, { config }),
-    };
+    }
   } catch {
-    return { error: "Invalid script" };
+    return { error: "Invalid script" }
   }
 }


### PR DESCRIPTION
# Description

This PR

1. deprecated the submodule `helpers` in `@ckb-lumos/lumos/config` and `@ckb-lumos/config-manager` to avoid confusion with `@ckb-lumos/helpers`
2. fixed the address conversion 

```ts
import { helpers } from '@ckb-lumos/lumos/config' // Not Recommended
import { helpers } from '@ckb-lumos/config-manager' // Not Recommended
import { nameOfScript } from '@ckb-lumos/lumos/config' // Recommended
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)