### PR TITLE
feat(config-manager): supported refresh deployment config

### DIFF
--- a/.changeset/grumpy-plants-pretend.md
+++ b/.changeset/grumpy-plants-pretend.md
@@ -1,0 +1,5 @@
+---
+"@ckb-lumos/config-manager": minor
+---
+
+feat: `refreshScriptConfigs` to refresh deployment config

--- a/examples/misc/refresh-config.ts
+++ b/examples/misc/refresh-config.ts
@@ -1,0 +1,32 @@
+// This example shows how to automatically refresh the script config
+// to avoid the "Unknown OutPoint(...)" error when the script is deployed with type id.
+
+import { config, RPC } from "@ckb-lumos/lumos";
+
+const rpc = new RPC("https://testnet.ckb.dev");
+
+async function main() {
+  const outdatedConfig: config.ScriptConfigs = {
+    OMNILOCK: {
+      CODE_HASH: "0xf329effd1c475a2978453c8600e1eaf0bc2087ee093c3ee64cc96ec6847752cb",
+      HASH_TYPE: "type",
+      // an outdated deployment transaction
+      // https://pudge.explorer.nervos.org/transaction/0xff234bf2fb0ad2ab5b356ceda317d3dee3efb2c55b9427ef55d9dcbf6eecbf9f
+      TX_HASH: "0xff234bf2fb0ad2ab5b356ceda317d3dee3efb2c55b9427ef55d9dcbf6eecbf9f",
+      INDEX: "0x0",
+      DEP_TYPE: "code",
+    },
+  };
+  const refreshed = await config.refreshScriptConfigs(outdatedConfig, {
+    resolve: config.createRpcResolver(rpc),
+  });
+
+  console.assert(
+    outdatedConfig.OMNILOCK?.TX_HASH !== refreshed.OMNILOCK?.TX_HASH,
+    "Omnilock script config should be refreshed"
+  );
+
+  console.log("The latest Omnilock is deployed at", refreshed.OMNILOCK?.TX_HASH);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@devtools/changelog": "workspace:^",
     "@strictsoftware/typedoc-plugin-monorepo": "^0.3.1",
     "@types/node": "^20.1.0",
+    "@types/sinon": "^17.0.3",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "ava": "^3.8.2",

--- a/packages/config-manager/README.md
+++ b/packages/config-manager/README.md
@@ -4,12 +4,25 @@
 
 ```ts
 import { initializeConfig, predefined } from '@ckb-lumos/config';
-import { generateAddress } from '@ckb-lumos/helper'
+import { encodeToAddress } from '@ckb-lumos/helper'
 
 initializeConfig(predefined.AGGRON);
-generateAddress({...}) // ckt1...
+encodeToAddress({...}) // ckt1...
 
 
 initializeConfig(predefined.LINA);
-generateAddress({...}) // ckb1...
+encodeToAddress({...}) // ckb1...
+```
+
+## Refreshing Config
+
+```ts
+import { refreshScriptConfig } from "@ckb-lumos/config";
+import { RPC } from "@ckb-lumos/rpc";
+
+const rpc = new RPC("http://localhost:8114");
+
+const refreshed = await refreshScriptConfigs(predefined.AGGRON4.SCRIPTS, {
+  resolve: createRpcResolver(rpc),
+});
 ```

--- a/packages/config-manager/package.json
+++ b/packages/config-manager/package.json
@@ -37,6 +37,7 @@
     "@ckb-lumos/base": "0.22.0-next.2",
     "@ckb-lumos/bi": "0.22.0-next.2",
     "@ckb-lumos/codec": "0.22.0-next.2",
+    "@ckb-lumos/rpc": "0.22.0-next.2",
     "@types/deep-freeze-strict": "^1.1.0",
     "deep-freeze-strict": "^1.1.1"
   },

--- a/packages/config-manager/src/index.ts
+++ b/packages/config-manager/src/index.ts
@@ -7,3 +7,8 @@ export * as helpers from "./helpers";
 export { nameOfScript, findConfigByScript } from "./helpers";
 export { predefined, createConfig } from "./predefined";
 export { generateGenesisScriptConfigs } from "./genesis";
+export {
+  refreshScriptConfigs,
+  createRpcResolver,
+  createLatestTypeIdResolver,
+} from "./refresh";

--- a/packages/config-manager/src/refresh.ts
+++ b/packages/config-manager/src/refresh.ts
@@ -112,7 +112,7 @@ type RefreshConfig<S> = {
 /**
  * Refreshing the config items in {@link ScriptConfigs} which are deployed with type id
  * @example
- * const updatedScriptConfigs = refreshScriptConfigs(predefined.AGGRON4.SCRIPTS, createRpcResolver(rpc))
+ * const updatedScriptConfigs = await refreshScriptConfigs(predefined.AGGRON4.SCRIPTS, { resolve: createRpcResolver(rpc) })
  * initializeConfig({ SCRIPTS: updatedScriptConfigs })
  */
 export async function refreshScriptConfigs<S extends ScriptConfigs>(

--- a/packages/config-manager/src/refresh.ts
+++ b/packages/config-manager/src/refresh.ts
@@ -15,7 +15,7 @@ export type FetchOutputsByTxHashes = (txHashes: string[]) => MaybePromise<{ outp
 /**
  * fetch cells with corresponding type script
  */
-export type FetchOutPointByTypeId = (scripts: Script[]) => MaybePromise<{ outPoint: OutPoint }[]>;
+export type FetchOutPointsByTypeIds = (scripts: Script[]) => MaybePromise<{ outPoint: OutPoint }[]>;
 
 // prettier-ignore
 /**
@@ -44,13 +44,13 @@ export function createRpcResolver(
     });
   };
 
-  const fetchIndexerCells: FetchOutPointByTypeId = async (typeIds) => {
+  const fetchIndexerCells: FetchOutPointsByTypeIds = async (scripts) => {
     const res = await rpc
       .createBatchRequest<unknown[], CKBComponents.GetLiveCellsResult<false>>(
-        typeIds.map((typeId) => [
+        scripts.map((script) => [
           "getCells",
           {
-            script: typeId,
+            script,
             scriptType: "type",
             scriptSearchMode: "exact",
             withData: false,
@@ -69,7 +69,7 @@ export function createRpcResolver(
 
 export function createLatestTypeIdResolver(
   fetchOutputs: FetchOutputsByTxHashes,
-  fetchTypeScriptCell: FetchOutPointByTypeId
+  fetchTypeScriptCell: FetchOutPointsByTypeIds
 ): ResolveLatestOutPointsOfTypeIds {
   return async (oldOutPoints) => {
     const txs = await fetchOutputs(

--- a/packages/config-manager/src/refresh.ts
+++ b/packages/config-manager/src/refresh.ts
@@ -1,0 +1,164 @@
+import type {
+  OutPoint,
+  Script,
+  Transaction,
+  TransactionWithStatus,
+} from "@ckb-lumos/base";
+import type { ScriptConfig, ScriptConfigs } from "./types";
+import type { RPC } from "@ckb-lumos/rpc";
+import type { CKBComponents } from "@ckb-lumos/rpc/lib/types/api";
+
+type MaybePromise<T> = T | PromiseLike<T>;
+
+type LatestOutpointResolver = (
+  outPoints: OutPoint[]
+) => MaybePromise<OutPoint[]>;
+
+type FetchTxs = (txHashes: string[]) => MaybePromise<Transaction[]>;
+type FetchTypeIdCells = (
+  scripts: Script[]
+) => MaybePromise<CKBComponents.IndexerCellWithoutData[]>;
+
+/* c8 ignore next 39 */
+export function createRpcResolver(rpc: RPC): LatestOutpointResolver {
+  const fetchTxs: FetchTxs = async (txHashes) => {
+    const txs: TransactionWithStatus[] = await rpc
+      .createBatchRequest(txHashes.map((txHash) => ["getTransaction", txHash]))
+      .exec();
+
+    return zipWith(txHashes, txs, (txHash, tx) => {
+      if (!tx?.transaction) {
+        throw new Error(`Cannot find transaction ${txHash}`);
+      }
+      return tx.transaction;
+    });
+  };
+
+  const fetchIndexerCells: FetchTypeIdCells = async (typeIds) => {
+    const res: CKBComponents.GetLiveCellsResult<false>[] = await rpc
+      .createBatchRequest(
+        typeIds.map((typeId) => [
+          "getCells",
+          {
+            script: typeId,
+            scriptType: "type",
+            scriptSearchMode: "exact",
+            withData: false,
+          } satisfies CKBComponents.GetCellsSearchKey<false>,
+          "asc" satisfies CKBComponents.Order,
+          "0x1" satisfies CKBComponents.UInt64,
+        ])
+      )
+      .exec();
+
+    return res.map<CKBComponents.IndexerCellWithoutData>(
+      (item) => item.objects[0]
+    );
+  };
+
+  return createResolver(fetchTxs, fetchIndexerCells);
+}
+
+export function createResolver(
+  fetchTxs: FetchTxs,
+  fetchTypeScriptCell: FetchTypeIdCells
+): LatestOutpointResolver {
+  return async (oldOutPoints) => {
+    const txs = await fetchTxs(oldOutPoints.map((outPoint) => outPoint.txHash));
+
+    const typeScripts = zipWith(oldOutPoints, txs, (outPoint, tx) => {
+      nonNullable(outPoint);
+
+      nonNullable(
+        tx,
+        `Cannot find the OutPoint ${outPoint.txHash}#${outPoint.index}`
+      );
+
+      return tx.outputs[Number(outPoint.index)].type;
+    });
+
+    const cells = await fetchTypeScriptCell(
+      typeScripts.filter(Boolean) as Script[]
+    );
+
+    return zipWith(oldOutPoints, typeScripts, (oldOutPoint, script) => {
+      nonNullable(oldOutPoint);
+      if (!script) {
+        return oldOutPoint;
+      }
+
+      const [cell] = cells.splice(0, 1);
+      return cell.outPoint;
+    });
+  };
+}
+
+type RefreshConfig<S> = {
+  resolve: LatestOutpointResolver;
+  skip?: (keyof S)[];
+};
+
+/**
+ * Refreshing the config items in {@link ScriptConfigs} which are deployed with type id
+ * @example
+ * const updatedScriptConfigs = upgrade(predefined.AGGRON4.SCRIPTS, createRpcResolver(rpc))
+ * initializeConfig({ SCRIPTS: updatedScriptConfigs })
+ */
+export async function refreshScriptConfigs<S extends ScriptConfigs>(
+  scriptConfigs: S,
+  {
+    resolve,
+    skip = ["SECP256K1_BLAKE160", "SECP256K1_BLAKE160_MULTISIG", "DAO"],
+  }: RefreshConfig<S>
+): Promise<S> {
+  // prettier-ignore
+  type Filter = (value: [string, ScriptConfig | undefined]) => value is [string, ScriptConfig];
+
+  const configs = Object.entries(scriptConfigs).filter(
+    (([name, scriptConfig]) =>
+      !skip.includes(name) && scriptConfig?.HASH_TYPE === "type") as Filter
+  );
+
+  const oldOutPoints: OutPoint[] = configs.map(([_, scriptConfig]) => ({
+    txHash: scriptConfig.TX_HASH,
+    index: scriptConfig.INDEX,
+  }));
+
+  const newOutPoints: OutPoint[] = await resolve(oldOutPoints);
+
+  const newScriptConfigs = Object.fromEntries(
+    zipWith(configs, newOutPoints, (target, newOutPoint) => {
+      nonNullable(target);
+      const [name, original] = target;
+
+      nonNullable(
+        newOutPoint,
+        `Refreshing failed, cannot load config of ${name}, please check whether the scriptConfig is correct`
+      );
+
+      return [
+        name,
+        { ...original, TX_HASH: newOutPoint.txHash, INDEX: newOutPoint.index },
+      ];
+    })
+  );
+
+  return Object.assign({}, scriptConfigs, newScriptConfigs);
+}
+
+function zipWith<A, B, T>(
+  a: A[],
+  b: B[],
+  cb: (a: A | undefined, b: B | undefined) => T
+) {
+  return a.map((_, i) => cb(a[i], b[i]));
+}
+
+function nonNullable<T>(
+  t: T,
+  message = "Not nullable"
+): asserts t is NonNullable<T> {
+  if (t == null) {
+    throw new Error(message);
+  }
+}

--- a/packages/config-manager/tests/refresh.test.ts
+++ b/packages/config-manager/tests/refresh.test.ts
@@ -1,0 +1,60 @@
+import test from "ava";
+import { refreshScriptConfigs } from "../src/refresh";
+import { ScriptConfigs } from "../src";
+import { hexify } from "@ckb-lumos/codec/lib/bytes";
+import { randomBytes } from "node:crypto";
+
+function randomHash() {
+  return hexify(randomBytes(32));
+}
+
+test("refresh without update", async (t) => {
+  const scriptConfigs: ScriptConfigs = {
+    A: {
+      CODE_HASH: randomHash(),
+      TX_HASH: randomHash(),
+      HASH_TYPE: "type",
+      DEP_TYPE: "code",
+      INDEX: "0x1",
+    },
+    B: {
+      CODE_HASH: randomHash(),
+      TX_HASH: randomHash(),
+      HASH_TYPE: "type",
+      DEP_TYPE: "code",
+      INDEX: "0x1",
+    },
+  };
+  const refreshed1 = await refreshScriptConfigs(scriptConfigs, {
+    resolve: (outPoints) => outPoints,
+  });
+
+  t.deepEqual(refreshed1, scriptConfigs);
+});
+
+test("refresh with skip", async (t) => {
+  const scriptConfigs: ScriptConfigs = {
+    A: {
+      CODE_HASH: randomHash(),
+      TX_HASH: randomHash(),
+      HASH_TYPE: "type",
+      DEP_TYPE: "code",
+      INDEX: "0x1",
+    },
+    B: {
+      CODE_HASH: randomHash(),
+      TX_HASH: randomHash(),
+      HASH_TYPE: "type",
+      DEP_TYPE: "code",
+      INDEX: "0x1",
+    },
+  };
+  const refreshed2 = await refreshScriptConfigs(scriptConfigs, {
+    resolve: async (outPoints) =>
+      outPoints.map(() => ({ txHash: randomHash(), index: "0x0" })),
+    skip: ["B"],
+  });
+
+  t.notDeepEqual(scriptConfigs.A, refreshed2.A);
+  t.deepEqual(scriptConfigs.B, refreshed2.B);
+});

--- a/packages/config-manager/tests/refresh.test.ts
+++ b/packages/config-manager/tests/refresh.test.ts
@@ -1,12 +1,14 @@
 import test from "ava";
-import { refreshScriptConfigs } from "../src/refresh";
+import {
+  createLatestTypeIdResolver,
+  FetchOutputsByTxHashes,
+  refreshScriptConfigs,
+} from "../src/refresh";
 import { ScriptConfigs } from "../src";
 import { hexify } from "@ckb-lumos/codec/lib/bytes";
 import { randomBytes } from "node:crypto";
-
-function randomHash() {
-  return hexify(randomBytes(32));
-}
+import { OutPoint, Output, Script } from "@ckb-lumos/base";
+import sinon from "sinon";
 
 test("refresh without update", async (t) => {
   const scriptConfigs: ScriptConfigs = {
@@ -58,3 +60,78 @@ test("refresh with skip", async (t) => {
   t.notDeepEqual(scriptConfigs.A, refreshed2.A);
   t.deepEqual(scriptConfigs.B, refreshed2.B);
 });
+
+test("resolve empty outpoints should be empty", async (t) => {
+  const resolve = createLatestTypeIdResolver(
+    (hashes) => hashes.map(() => ({ outputs: [randomOutput()] })),
+    (scripts) => scripts.map(() => ({ outPoint: randomOutPoint() }))
+  );
+
+  t.deepEqual([], await resolve([]));
+});
+
+test("LatestTypeIdResolver should work as expected", async (t) => {
+  const originalOutPoint = randomOutPoint();
+  const originalOutput = randomOutput();
+  const latestOutPoint = randomOutPoint();
+
+  const fetchOutputsByTxHashes = sinon.spy((hashes) => {
+    return hashes.map(() => ({ outputs: [originalOutput] }));
+  });
+
+  const fetchLatestTypeIdOutPoints = sinon.spy((scripts) =>
+    scripts.map(() => ({ outPoint: latestOutPoint }))
+  );
+
+  const resolve = createLatestTypeIdResolver(
+    fetchOutputsByTxHashes,
+    fetchLatestTypeIdOutPoints
+  );
+
+  const resolved = await resolve([originalOutPoint]);
+
+  t.true(fetchOutputsByTxHashes.calledWith([originalOutPoint.txHash]));
+  t.true(fetchLatestTypeIdOutPoints.calledWith([originalOutput.type]));
+  t.deepEqual(resolved, [latestOutPoint]);
+});
+
+test("should resolve as original OutPoint if type script is empty", async (t) => {
+  const originalOutPoint = randomOutPoint();
+
+  const fetchOutputsByTxHashes = sinon.spy(((hashes: string[]) =>
+    hashes.map(() => ({
+      outputs: [{ capacity: "0x0", lock: randomScript() }],
+    }))) satisfies FetchOutputsByTxHashes);
+
+  const resolve = createLatestTypeIdResolver(fetchOutputsByTxHashes, () => []);
+  const resolved = await resolve([originalOutPoint]);
+  t.deepEqual(resolved, [originalOutPoint]);
+});
+
+function randomOutPoint(): OutPoint {
+  return { txHash: randomHash(), index: "0x0" };
+}
+
+function randomOutput(): Output {
+  return {
+    capacity: randomHex(8),
+    type: randomScript(),
+    lock: randomScript(),
+  };
+}
+
+function randomScript(): Script {
+  return {
+    codeHash: randomHash(),
+    hashType: "type",
+    args: hexify(randomBytes(20)),
+  };
+}
+
+function randomHash() {
+  return randomHex(32);
+}
+
+function randomHex(size: number) {
+  return hexify(randomBytes(size));
+}

--- a/packages/lumos/src/config.ts
+++ b/packages/lumos/src/config.ts
@@ -20,9 +20,9 @@ export {
    * @deprecated use the {@link nameOfScript} and {@link findConfigByScript} function instead
    */
   helpers,
-} from "@ckb-lumos/config-manager";
-
-export {
   nameOfScript,
   findConfigByScript,
-} from "@ckb-lumos/config-manager/lib/helpers";
+  refreshScriptConfigs,
+  createRpcResolver,
+  createLatestTypeIdResolver,
+} from "@ckb-lumos/config-manager";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -47,6 +47,9 @@ importers:
       '@types/node':
         specifier: ^20.1.0
         version: 20.1.0
+      '@types/sinon':
+        specifier: ^17.0.3
+        version: 17.0.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.59.2
         version: 5.59.2(@typescript-eslint/parser@5.59.2)(eslint@8.40.0)(typescript@5.0.4)
@@ -264,6 +267,9 @@ importers:
       '@ckb-lumos/codec':
         specifier: 0.22.0-next.2
         version: link:../codec
+      '@ckb-lumos/rpc':
+        specifier: 0.22.0-next.2
+        version: link:../rpc
       '@types/deep-freeze-strict':
         specifier: ^1.1.0
         version: 1.1.0
@@ -6284,6 +6290,12 @@ packages:
     resolution: {integrity: sha512-6EF+wzMWvBNeGrfP3Nx60hhx+FfwSg1JJBLAAP/IdIUq0EYkqCYf70VT3PhuhPX9eLD+Dp+lNdpb/ZeHG8Yezg==}
     dependencies:
       '@sinonjs/fake-timers': 7.1.2
+    dev: true
+
+  /@types/sinon@17.0.3:
+    resolution: {integrity: sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==}
+    dependencies:
+      '@types/sinonjs__fake-timers': 8.1.2
     dev: true
 
   /@types/sinonjs__fake-timers@8.1.2:


### PR DESCRIPTION
# Description

Fixes #609

This PR provided a method `refreshScriptConfigs` to refresh deployment configs for `ScriptConfigs`, developers can use the method to refresh configs, such as the `OMNILOCK` in `predefined.AGGRON4.SCRIPTS`

```ts
const refreshed = await refreshScriptConfigs(
  predefined.AGGRON4.SCRIPTS,
  { resolve: createRpcResolver(rpc) }
);
initializeConfig({SCRIPTS: refreshed, PREFIX: 'ckt'});
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

- [x] unit test

