### PR TITLE
docs: fixed typo in config-manager doc

### DIFF
--- a/packages/config-manager/README.md
+++ b/packages/config-manager/README.md
@@ -3,7 +3,9 @@
 ## Example
 
 ```ts
-import { initializeConfig, predefined } from '@ckb-lumos/lumos/config';
+import { initializeConfig, predefined } from "@ckb-lumos/config-manager"
+// or import from the entry package
+import { initializeConfig, predefined } from "@ckb-lumos/lumos/config"
 import { encodeToAddress } from '@ckb-lumos/helper'
 
 initializeConfig(predefined.AGGRON);

--- a/packages/config-manager/README.md
+++ b/packages/config-manager/README.md
@@ -19,7 +19,9 @@ encodeToAddress({...}) // ckb1...
 ## Refreshing Config
 
 ```ts
-import { refreshScriptConfigs } from "@ckb-lumos/lumos/config";
+import { initializeConfig, predefined } from "@ckb-lumos/config-manager"
+// or import from the entry package
+import { initializeConfig, predefined } from "@ckb-lumos/lumos/config"
 import { RPC } from "@ckb-lumos/rpc";
 
 const rpc = new RPC("http://localhost:8114");

--- a/packages/config-manager/README.md
+++ b/packages/config-manager/README.md
@@ -19,9 +19,9 @@ encodeToAddress({...}) // ckb1...
 ## Refreshing Config
 
 ```ts
-import { initializeConfig, predefined } from "@ckb-lumos/config-manager"
+import { refreshScriptConfigs } from "@ckb-lumos/config-manager"
 // or import from the entry package
-import { initializeConfig, predefined } from "@ckb-lumos/lumos/config"
+import { refreshScriptConfigs } from "@ckb-lumos/lumos/config"
 import { RPC } from "@ckb-lumos/rpc";
 
 const rpc = new RPC("http://localhost:8114");

--- a/packages/config-manager/README.md
+++ b/packages/config-manager/README.md
@@ -17,7 +17,7 @@ encodeToAddress({...}) // ckb1...
 ## Refreshing Config
 
 ```ts
-import { refreshScriptConfig } from "@ckb-lumos/config";
+import { refreshScriptConfigs } from "@ckb-lumos/lumos/config";
 import { RPC } from "@ckb-lumos/rpc";
 
 const rpc = new RPC("http://localhost:8114");

--- a/packages/config-manager/README.md
+++ b/packages/config-manager/README.md
@@ -3,7 +3,7 @@
 ## Example
 
 ```ts
-import { initializeConfig, predefined } from '@ckb-lumos/config';
+import { initializeConfig, predefined } from '@ckb-lumos/lumos/config';
 import { encodeToAddress } from '@ckb-lumos/helper'
 
 initializeConfig(predefined.AGGRON);


### PR DESCRIPTION
# Description

Fixed a typo in the documentation related to an API call  in `./lumos/packages/config-manager/README.md`, and also corrected the issue with the API reference path. from `"@ckb-lumos/config"` to `"@ckb-lumos/lumos/config"`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Documentation or Website




