### PR TITLE
feat: export parse from debugger

### DIFF
--- a/packages/debugger/src/executor.ts
+++ b/packages/debugger/src/executor.ts
@@ -86,6 +86,7 @@ export class CKBDebugger implements Executor {
         buf.stderr.toString("utf-8")
       );
     } else {
+      /* c8 ignore next 3 */
       throw new Error(
         `Failed to install ckb-debugger or ckb-debugger can't be located at ${this.debuggerPath}`
       );

--- a/packages/debugger/src/executor.ts
+++ b/packages/debugger/src/executor.ts
@@ -79,9 +79,16 @@ export class CKBDebugger implements Executor {
       }
     );
 
-    return parseDebuggerMessage(
-      buf.stdout.toString("utf-8"),
-      buf.stderr.toString("utf-8")
-    );
+    // when ckb-debugger can't be located, they're null.
+    if (buf.stdout != null && buf.stderr != null) {
+      return parseDebuggerMessage(
+        buf.stdout.toString("utf-8"),
+        buf.stderr.toString("utf-8")
+      );
+    } else {
+      throw new Error(
+        `Failed to install ckb-debugger or ckb-debugger can't be located at ${this.debuggerPath}`
+      );
+    }
   }
 }

--- a/packages/debugger/src/index.ts
+++ b/packages/debugger/src/index.ts
@@ -2,3 +2,4 @@ export { CKBDebugger } from "./executor";
 export { createTestContext, getDefaultConfig } from "./context";
 export { CKBDebuggerDownloader } from "./download";
 export * from "./types";
+export * as parse from "./parse";


### PR DESCRIPTION
Changes:
The parseDebuggerData is useful to print json to stdout.  Fix a minor bug when ckb-debugger is missing.

Maybe this PR is not perfect. The requirement is to export `parseDebuggerData` or similar function. Feel free to use you own updates.
