### PR TITLE
fix(debugger): conflict while running debugger in parallel

### DIFF
--- a/packages/debugger/src/executor.ts
+++ b/packages/debugger/src/executor.ts
@@ -6,6 +6,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { parseDebuggerData, parseDebuggerMessage } from "./parse";
+import * as crypto from 'crypto';
 
 interface DebuggerOptions {
   readonly loader: DataLoader;
@@ -50,9 +51,9 @@ export class CKBDebugger implements Executor {
    */
   private saveTmpTxFile(txSkeleton: TransactionSkeletonType): string {
     const debuggerData = parseDebuggerData(txSkeleton, this.loader);
-
-    // TODO replace with random tmp file name to avoid conflict
-    const tmpTxPath = path.join(os.tmpdir(), "ckb_debugger_tx.json");
+    const randomHash = crypto.randomBytes(18).toString('hex');    
+    const tempFileName = `lumos-debugger-data-${randomHash}`    
+    const tmpTxPath = path.join(os.tmpdir(), `${tempFileName}.json`);
     fs.writeFileSync(tmpTxPath, JSON.stringify(debuggerData));
 
     return tmpTxPath;

--- a/packages/debugger/src/executor.ts
+++ b/packages/debugger/src/executor.ts
@@ -51,8 +51,8 @@ export class CKBDebugger implements Executor {
    */
   private saveTmpTxFile(txSkeleton: TransactionSkeletonType): string {
     const debuggerData = parseDebuggerData(txSkeleton, this.loader);
-    const randomHash = crypto.randomBytes(18).toString('hex');    
-    const tempFileName = `lumos-debugger-data-${randomHash}`    
+    const randomHex = crypto.randomBytes(18).toString('hex');    
+    const tempFileName = `lumos-debugger-data-${randomHex}`    
     const tmpTxPath = path.join(os.tmpdir(), `${tempFileName}.json`);
     fs.writeFileSync(tmpTxPath, JSON.stringify(debuggerData));
 


### PR DESCRIPTION
Fixes #625 

This PR fixes is that when the user executes the debugger, a predictable temporary file is generated to avoid filename conflicts.
