### PR TITLE
Feature molecule import statement support

### DIFF
--- a/packages/molecule/src/codegen.ts
+++ b/packages/molecule/src/codegen.ts
@@ -47,7 +47,7 @@ export function codegen(schema: string, options: Options = {}): string {
 
   const codecs = molTypes
     .map((molType) => {
-      if (importedModules.includes(molType.name)) return "";
+      if (molType.name && importedModules.includes(molType.name)) return "";
 
       if (molType.type === "array") {
         if (molType.item === "byte") {
@@ -156,7 +156,7 @@ function prepareMolTypes(
 ): MolType[] {
   // check if the molecule definition can be parsed
   function checkCanParse(molType: MolType): boolean {
-    if (availableTypes.has(molType.name)) {
+    if (molType.name && availableTypes.has(molType.name)) {
       return true;
     }
 
@@ -220,7 +220,7 @@ function prepareMolTypes(
     scanTimes++;
 
     const molType = iterator.current()!;
-    if (checkCanParse(molType)) {
+    if (molType.name && checkCanParse(molType)) {
       sortedTypes.push(molType);
       availableTypes.add(molType.name);
       iterator.removeAndNext();
@@ -232,7 +232,7 @@ function prepareMolTypes(
 
   if (scanTimes >= maxScanTimes) {
     const unknownTypes = types
-      .filter((type) => !availableTypes.has(type.name))
+      .filter((type) => type.name && !availableTypes.has(type.name))
       .map((type) => type.name)
       .join(", ");
 

--- a/packages/molecule/src/nearley.ts
+++ b/packages/molecule/src/nearley.ts
@@ -12,7 +12,7 @@ import {
   Parser,
   ParseOptions,
   Import,
-  CodecMap
+  CodecMap,
 } from "./type";
 import { nonNull, toMolTypeMap, parseImportStatement } from "./utils";
 import { Uint32 } from "@ckb-lumos/codec/lib/number";
@@ -33,7 +33,7 @@ export const createParser = (): Parser => {
       data = data.replace(/import\s+([^;]+);/g, (match, importsStr) => {
         const importStatement = `import ${importsStr};`;
         imports.push(parseImportStatement(importStatement));
-        return '';
+        return "";
       });
       const parser = new NearleyParser(NearleyGrammar.fromCompiled(grammar));
       parser.feed(data);
@@ -44,7 +44,7 @@ export const createParser = (): Parser => {
       const codecMap = createCodecMap(results, option.refs);
       const combinedResult: CodecMap = { ...codecMap };
       imports.forEach((importItem) => {
-        combinedResult[importItem.name || 'Unnamed'] = importItem;
+        combinedResult[importItem.name || "Unnamed"] = importItem;
       });
       return createCodecMap(combinedResult, option.refs);
     },
@@ -67,13 +67,13 @@ const checkDuplicateNames = (results: MolType[]) => {
   const names = new Set<string>();
   results.forEach((result) => {
     const currentName = result.name;
-    if (typeof currentName === 'string') {
+    if (typeof currentName === "string") {
       if (names.has(currentName)) {
         throw new Error(`Duplicate name: ${currentName}`);
       }
       names.add(currentName);
     } else {
-      throw new Error('Name is null or undefined');
+      throw new Error("Name is null or undefined");
     }
     const currentType = result.type;
     // check duplicate field names in `struct` and `table`

--- a/packages/molecule/src/nearley.ts
+++ b/packages/molecule/src/nearley.ts
@@ -46,7 +46,7 @@ export const createParser = (): Parser => {
       imports.forEach((importItem) => {
         combinedResult[importItem.name || "Unnamed"] = importItem;
       });
-      return createCodecMap(combinedResult, option.refs);
+      return combinedResult;
     },
   };
 };

--- a/packages/molecule/src/type.ts
+++ b/packages/molecule/src/type.ts
@@ -42,8 +42,17 @@ export type Table = {
   fields: Field[];
 };
 
+export type Import = {
+  type: "import";
+  name?: string | null;
+  defaultImport?: string | null;
+  exportedImports?: { name: string | null; alias?: string | null }[] | null;
+  alias?: string | null;
+  from?: string | null;
+};
+
 // mol types
-export type MolType = Array | Vector | Option | Union | Struct | Table;
+export type MolType = Array | Vector | Option | Union | Struct | Table | Import;
 
 // key is type name
 export type MolTypeMap = Record<string, MolType>;

--- a/packages/molecule/src/utils.ts
+++ b/packages/molecule/src/utils.ts
@@ -14,151 +14,176 @@ export const toMolTypeMap = (results: MolType[]): MolTypeMap => {
   return map;
 };
 
-const determineImportType = (importStatement: String) => {
-  const parts = importStatement.split(' ');
-  const defaultExportExists = parts.includes('defaultExport,') || parts.includes('defaultExport');
+const determineImportType = (importStatement: string) => {
+  const parts = importStatement.split(" ");
+  const defaultExportExists =
+    parts.includes("defaultExport,") || parts.includes("defaultExport");
   const secondPart = parts[1];
   const importTypeThreeFourSecondPart = parts[0];
-  if (defaultExportExists && secondPart === '{') {
-    return 'importTypeOne';
-  }
-  else if (defaultExportExists && secondPart !== '{' && secondPart !== '*' && parts.includes('from')) {
-    return 'importTypeTwo';
-  }
-  else if (!defaultExportExists && importTypeThreeFourSecondPart === '{') {
+  if (defaultExportExists && secondPart === "{") {
+    return "importTypeOne";
+  } else if (
+    defaultExportExists &&
+    secondPart !== "{" &&
+    secondPart !== "*" &&
+    parts.includes("from")
+  ) {
+    return "importTypeTwo";
+  } else if (!defaultExportExists && importTypeThreeFourSecondPart === "{") {
     const braceContent = importStatement.substring(
-      importStatement.indexOf('{') + 1,
-      importStatement.indexOf('}')
+      importStatement.indexOf("{") + 1,
+      importStatement.indexOf("}")
     );
-    const asCount = braceContent.split(' as ').length - 1;
-    if (asCount === 1 && parts.includes('from')) {
-      return 'importTypeThree';
+    const asCount = braceContent.split(" as ").length - 1;
+    if (asCount === 1 && parts.includes("from")) {
+      return "importTypeThree";
     } else {
-      return 'importTypeSix';
+      return "importTypeSix";
     }
+  } else if (importTypeThreeFourSecondPart === "*" && parts.includes("from")) {
+    return "importTypeFour";
+  } else if (
+    defaultExportExists &&
+    secondPart === "*" &&
+    parts.includes("from")
+  ) {
+    return "importTypeFive";
   }
-  else if (importTypeThreeFourSecondPart === '*' && parts.includes('from')) {
-    return 'importTypeFour';
-  }
-  else if (defaultExportExists && secondPart === '*' && parts.includes('from')) {
-    return 'importTypeFive';
-  }
-  return 'unknownImportType';
+  return "unknownImportType";
 };
 
 const parseImportTypeOne = (importContent: string): Import => {
-  const braceContent = importContent.substring(importContent.indexOf('{') + 1, importContent.lastIndexOf('}'));
-  const exportedImports = braceContent.split(',').map(part => {
-    const [namePart, aliasPart] = part.split(' as ');
-    return { name: namePart.trim(), alias: aliasPart ? aliasPart.trim() : null };
+  const braceContent = importContent.substring(
+    importContent.indexOf("{") + 1,
+    importContent.lastIndexOf("}")
+  );
+  const exportedImports = braceContent.split(",").map((part) => {
+    const [namePart, aliasPart] = part.split(" as ");
+    return {
+      name: namePart.trim(),
+      alias: aliasPart ? aliasPart.trim() : null,
+    };
   });
-  let defaultImport = importContent.split('{')[0].trim().split(' ').pop();
-  if (defaultImport?.endsWith(',')) {
+  let defaultImport = importContent.split("{")[0].trim().split(" ").pop();
+  if (defaultImport?.endsWith(",")) {
     defaultImport = defaultImport.slice(0, -1);
   }
-  const fromIndex = importContent.indexOf('from');
-  let from = fromIndex !== -1 ? importContent.substring(fromIndex + 4).trim() : null;
+  const fromIndex = importContent.indexOf("from");
+  let from =
+    fromIndex !== -1 ? importContent.substring(fromIndex + 4).trim() : null;
   if (from && from.startsWith('"') && from.endsWith('"')) {
     from = from.slice(1, -1);
   }
 
   return {
-    type: 'import',
-    name: 'importTypeOne',
+    type: "import",
+    name: "importTypeOne",
     defaultImport: defaultImport,
     exportedImports: exportedImports.length > 0 ? exportedImports : null,
     alias: null,
-    from: from ? from.replace(/['"]+/g, '') : null,
+    from: from ? from.replace(/['"]+/g, "") : null,
   };
 };
 
 const parseImportTypeTwo = (importContent: string): Import => {
-  const parts = importContent.split(' ').map(part => part.trim());
+  const parts = importContent.split(" ").map((part) => part.trim());
   const defaultImport = parts[0];
-  const fromIndex = parts.findIndex(part => part === 'from');
+  const fromIndex = parts.findIndex((part) => part === "from");
   const from = fromIndex !== -1 ? parts[fromIndex + 1] : null;
 
   return {
-    type: 'import',
-    name: 'importTypeTwo',
+    type: "import",
+    name: "importTypeTwo",
     defaultImport: defaultImport,
     exportedImports: null,
     alias: null,
-    from: from ? from.replace(/['"]+/g, '') : null,
+    from: from ? from.replace(/['"]+/g, "") : null,
   };
 };
 
 const parseImportTypeThree = (importContent: string): Import => {
-  const parts = importContent.split('{')[1].split('}')[0].split(',').map(part => part.trim());
-  const exportedImports = parts.map(part => {
-    const [namePart, aliasPart] = part.split(' as ');
-    return { name: namePart.trim(), alias: aliasPart ? aliasPart.trim() : null };
+  const parts = importContent
+    .split("{")[1]
+    .split("}")[0]
+    .split(",")
+    .map((part) => part.trim());
+  const exportedImports = parts.map((part) => {
+    const [namePart, aliasPart] = part.split(" as ");
+    return {
+      name: namePart.trim(),
+      alias: aliasPart ? aliasPart.trim() : null,
+    };
   });
-  const fromIndex = importContent.indexOf('from');
-  const from = fromIndex !== -1 ? importContent.substring(fromIndex + 5).trim() : null;
+  const fromIndex = importContent.indexOf("from");
+  const from =
+    fromIndex !== -1 ? importContent.substring(fromIndex + 5).trim() : null;
 
   return {
-    type: 'import',
-    name: 'importTypeThree',
+    type: "import",
+    name: "importTypeThree",
     defaultImport: null,
     exportedImports: exportedImports.length > 0 ? exportedImports : null,
     alias: null,
-    from: from ? from.replace(/['"]+/g, '') : null,
+    from: from ? from.replace(/['"]+/g, "") : null,
   };
 };
 
 const parseImportTypeFour = (importContent: string): Import => {
-  const parts = importContent.split(' ').map(part => part.trim());
+  const parts = importContent.split(" ").map((part) => part.trim());
   const alias = parts[2];
-  const fromIndex = parts.findIndex(part => part === 'from');
+  const fromIndex = parts.findIndex((part) => part === "from");
   const from = fromIndex !== -1 ? parts[fromIndex + 1] : null;
 
   return {
-    type: 'import',
-    name: 'importTypeFour',
+    type: "import",
+    name: "importTypeFour",
     defaultImport: null,
     exportedImports: null,
-    alias: alias ? alias.replace(/['"]+/g, '') : null,
-    from: from ? from.replace(/['"]+/g, '') : null,
+    alias: alias ? alias.replace(/['"]+/g, "") : null,
+    from: from ? from.replace(/['"]+/g, "") : null,
   };
 };
 
 const parseImportTypeFive = (importContent: string): Import => {
-  const parts = importContent.split(' ').map(part => part.trim());
+  const parts = importContent.split(" ").map((part) => part.trim());
   let defaultImport = parts[0];
-  if (defaultImport.endsWith(',')) {
+  if (defaultImport.endsWith(",")) {
     defaultImport = defaultImport.slice(0, -1);
-  };
-  const fromIndex = parts.findIndex(part => part === 'from');
+  }
+  const fromIndex = parts.findIndex((part) => part === "from");
   const from = fromIndex !== -1 ? parts[fromIndex + 1] : null;
 
   return {
-    type: 'import',
-    name: 'importTypeFive',
+    type: "import",
+    name: "importTypeFive",
     defaultImport: defaultImport,
     exportedImports: null,
-    alias: from ? from.replace(/['"]+/g, '') : null,
-    from: from ? from.replace(/['"]+/g, '') : null,
+    alias: from ? from.replace(/['"]+/g, "") : null,
+    from: from ? from.replace(/['"]+/g, "") : null,
   };
 };
 
 const parseImportTypeSix = (importContent: string): Import => {
-  const braceContent = importContent.split('{')[1].split('}')[0];
-  const parts = braceContent.split(',').map(part => part.trim());
-  const exportedImports = parts.map(part => {
-    const [namePart, aliasPart] = part.split(' as ');
-    return { name: namePart.trim(), alias: aliasPart ? aliasPart.trim() : null };
+  const braceContent = importContent.split("{")[1].split("}")[0];
+  const parts = braceContent.split(",").map((part) => part.trim());
+  const exportedImports = parts.map((part) => {
+    const [namePart, aliasPart] = part.split(" as ");
+    return {
+      name: namePart.trim(),
+      alias: aliasPart ? aliasPart.trim() : null,
+    };
   });
-  const fromIndex = importContent.indexOf('from');
-  const from = fromIndex !== -1 ? importContent.substring(fromIndex + 5).trim() : null;
+  const fromIndex = importContent.indexOf("from");
+  const from =
+    fromIndex !== -1 ? importContent.substring(fromIndex + 5).trim() : null;
 
   return {
-    type: 'import',
-    name: 'importTypeSix',
+    type: "import",
+    name: "importTypeSix",
     defaultImport: null,
     exportedImports: exportedImports.length > 0 ? exportedImports : null,
     alias: null,
-    from: from ? from.replace(/['"]+/g, '') : null,
+    from: from ? from.replace(/['"]+/g, "") : null,
   };
 };
 
@@ -175,19 +200,19 @@ export const parseImportStatement = (statement: string): Import => {
   const importType = determineImportType(importContent);
 
   switch (importType) {
-    case 'importTypeOne':
+    case "importTypeOne":
       return parseImportTypeOne(importContent);
-    case 'importTypeTwo':
+    case "importTypeTwo":
       return parseImportTypeTwo(importContent);
-    case 'importTypeThree':
+    case "importTypeThree":
       return parseImportTypeThree(importContent);
-    case 'importTypeFour':
+    case "importTypeFour":
       return parseImportTypeFour(importContent);
-    case 'importTypeFive':
+    case "importTypeFive":
       return parseImportTypeFive(importContent);
-    case 'importTypeSix':
+    case "importTypeSix":
       return parseImportTypeSix(importContent);
     default:
       throw new Error(`Unknown import type: ${importType}`);
-  };
+  }
 };

--- a/packages/molecule/src/utils.ts
+++ b/packages/molecule/src/utils.ts
@@ -1,4 +1,4 @@
-import { MolType, MolTypeMap } from "./type";
+import { MolType, MolTypeMap, Import } from "./type";
 
 export function nonNull<T>(data: T): asserts data is NonNullable<T> {
   if (data === null || data === undefined) throw new Error("NonNullable");
@@ -7,7 +7,187 @@ export function nonNull<T>(data: T): asserts data is NonNullable<T> {
 export const toMolTypeMap = (results: MolType[]): MolTypeMap => {
   const map: MolTypeMap = {};
   results.forEach((result) => {
-    map[result.name] = result;
+    if (result.name !== null && result.name !== undefined) {
+      map[result.name] = result;
+    }
   });
   return map;
+};
+
+const determineImportType = (importStatement: String) => {
+  const parts = importStatement.split(' ');
+  const defaultExportExists = parts.includes('defaultExport,') || parts.includes('defaultExport');
+  const secondPart = parts[1];
+  const importTypeThreeFourSecondPart = parts[0];
+  if (defaultExportExists && secondPart === '{') {
+    return 'importTypeOne';
+  }
+  else if (defaultExportExists && secondPart !== '{' && secondPart !== '*' && parts.includes('from')) {
+    return 'importTypeTwo';
+  }
+  else if (!defaultExportExists && importTypeThreeFourSecondPart === '{') {
+    const braceContent = importStatement.substring(
+      importStatement.indexOf('{') + 1,
+      importStatement.indexOf('}')
+    );
+    const asCount = braceContent.split(' as ').length - 1;
+    if (asCount === 1 && parts.includes('from')) {
+      return 'importTypeThree';
+    } else {
+      return 'importTypeSix';
+    }
+  }
+  else if (importTypeThreeFourSecondPart === '*' && parts.includes('from')) {
+    return 'importTypeFour';
+  }
+  else if (defaultExportExists && secondPart === '*' && parts.includes('from')) {
+    return 'importTypeFive';
+  }
+  return 'unknownImportType';
+};
+
+const parseImportTypeOne = (importContent: string): Import => {
+  const braceContent = importContent.substring(importContent.indexOf('{') + 1, importContent.lastIndexOf('}'));
+  const exportedImports = braceContent.split(',').map(part => {
+    const [namePart, aliasPart] = part.split(' as ');
+    return { name: namePart.trim(), alias: aliasPart ? aliasPart.trim() : null };
+  });
+  let defaultImport = importContent.split('{')[0].trim().split(' ').pop();
+  if (defaultImport?.endsWith(',')) {
+    defaultImport = defaultImport.slice(0, -1);
+  }
+  const fromIndex = importContent.indexOf('from');
+  let from = fromIndex !== -1 ? importContent.substring(fromIndex + 4).trim() : null;
+  if (from && from.startsWith('"') && from.endsWith('"')) {
+    from = from.slice(1, -1);
+  }
+
+  return {
+    type: 'import',
+    name: 'importTypeOne',
+    defaultImport: defaultImport,
+    exportedImports: exportedImports.length > 0 ? exportedImports : null,
+    alias: null,
+    from: from ? from.replace(/['"]+/g, '') : null,
+  };
+};
+
+const parseImportTypeTwo = (importContent: string): Import => {
+  const parts = importContent.split(' ').map(part => part.trim());
+  const defaultImport = parts[0];
+  const fromIndex = parts.findIndex(part => part === 'from');
+  const from = fromIndex !== -1 ? parts[fromIndex + 1] : null;
+
+  return {
+    type: 'import',
+    name: 'importTypeTwo',
+    defaultImport: defaultImport,
+    exportedImports: null,
+    alias: null,
+    from: from ? from.replace(/['"]+/g, '') : null,
+  };
+};
+
+const parseImportTypeThree = (importContent: string): Import => {
+  const parts = importContent.split('{')[1].split('}')[0].split(',').map(part => part.trim());
+  const exportedImports = parts.map(part => {
+    const [namePart, aliasPart] = part.split(' as ');
+    return { name: namePart.trim(), alias: aliasPart ? aliasPart.trim() : null };
+  });
+  const fromIndex = importContent.indexOf('from');
+  const from = fromIndex !== -1 ? importContent.substring(fromIndex + 5).trim() : null;
+
+  return {
+    type: 'import',
+    name: 'importTypeThree',
+    defaultImport: null,
+    exportedImports: exportedImports.length > 0 ? exportedImports : null,
+    alias: null,
+    from: from ? from.replace(/['"]+/g, '') : null,
+  };
+};
+
+const parseImportTypeFour = (importContent: string): Import => {
+  const parts = importContent.split(' ').map(part => part.trim());
+  const alias = parts[2];
+  const fromIndex = parts.findIndex(part => part === 'from');
+  const from = fromIndex !== -1 ? parts[fromIndex + 1] : null;
+
+  return {
+    type: 'import',
+    name: 'importTypeFour',
+    defaultImport: null,
+    exportedImports: null,
+    alias: alias ? alias.replace(/['"]+/g, '') : null,
+    from: from ? from.replace(/['"]+/g, '') : null,
+  };
+};
+
+const parseImportTypeFive = (importContent: string): Import => {
+  const parts = importContent.split(' ').map(part => part.trim());
+  let defaultImport = parts[0];
+  if (defaultImport.endsWith(',')) {
+    defaultImport = defaultImport.slice(0, -1);
+  };
+  const fromIndex = parts.findIndex(part => part === 'from');
+  const from = fromIndex !== -1 ? parts[fromIndex + 1] : null;
+
+  return {
+    type: 'import',
+    name: 'importTypeFive',
+    defaultImport: defaultImport,
+    exportedImports: null,
+    alias: from ? from.replace(/['"]+/g, '') : null,
+    from: from ? from.replace(/['"]+/g, '') : null,
+  };
+};
+
+const parseImportTypeSix = (importContent: string): Import => {
+  const braceContent = importContent.split('{')[1].split('}')[0];
+  const parts = braceContent.split(',').map(part => part.trim());
+  const exportedImports = parts.map(part => {
+    const [namePart, aliasPart] = part.split(' as ');
+    return { name: namePart.trim(), alias: aliasPart ? aliasPart.trim() : null };
+  });
+  const fromIndex = importContent.indexOf('from');
+  const from = fromIndex !== -1 ? importContent.substring(fromIndex + 5).trim() : null;
+
+  return {
+    type: 'import',
+    name: 'importTypeSix',
+    defaultImport: null,
+    exportedImports: exportedImports.length > 0 ? exportedImports : null,
+    alias: null,
+    from: from ? from.replace(/['"]+/g, '') : null,
+  };
+};
+
+export const parseImportStatement = (statement: string): Import => {
+  const importRegex = /^import\s+([^;]+);?$/;
+  const match = statement.match(importRegex);
+
+  if (!match) {
+    throw new Error(`Invalid import statement: ${statement}`);
+  }
+
+  const importContent = match[1].trim();
+
+  const importType = determineImportType(importContent);
+
+  switch (importType) {
+    case 'importTypeOne':
+      return parseImportTypeOne(importContent);
+    case 'importTypeTwo':
+      return parseImportTypeTwo(importContent);
+    case 'importTypeThree':
+      return parseImportTypeThree(importContent);
+    case 'importTypeFour':
+      return parseImportTypeFour(importContent);
+    case 'importTypeFive':
+      return parseImportTypeFive(importContent);
+    case 'importTypeSix':
+      return parseImportTypeSix(importContent);
+    default:
+      throw new Error(`Unknown import type: ${importType}`);
+  };
 };

--- a/packages/molecule/tests/grammar.test.ts
+++ b/packages/molecule/tests/grammar.test.ts
@@ -11,6 +11,111 @@ test("should parse sample", (t) => {
   t.deepEqual(result.Uint8.unpack("0x01"), 1);
 });
 
+test("should parse import type 1", (t) => {
+  const parser = createParser();
+  const result = parser.parse(`
+    import defaultExport, { foo, bar as baz } from "module";
+  `);
+  const importResult = result.importTypeOne;
+  t.true(importResult !== undefined && importResult !== null);
+  t.true(importResult.type === "import");
+  t.true(importResult.name === "importTypeOne");
+  t.true(Array.isArray(importResult.exportedImports));
+  t.true(importResult.exportedImports.length === 2);
+  t.true(importResult.exportedImports[0].name === "foo");
+  t.true(importResult.exportedImports[0].alias === null);
+  t.true(importResult.exportedImports[1].name === "bar");
+  t.true(importResult.exportedImports[1].alias === "baz");
+  t.true(importResult.defaultImport === "defaultExport");
+  t.true(importResult.alias === null);
+  t.true(importResult.from === "module");
+});
+
+test("should parse import type 2", (t) => {
+  const parser = createParser();
+  const result = parser.parse(`
+    import defaultExport from "module";
+  `);
+  const importResult = result.importTypeTwo;
+  t.true(importResult !== undefined && importResult !== null);
+  t.true(importResult.type === "import");
+  t.true(importResult.name === "importTypeTwo");
+  t.true(importResult.defaultImport === "defaultExport");
+  t.true(importResult.exportedImports === null);
+  t.true(importResult.alias === null);
+  t.true(importResult.from === "module");
+});
+
+test("should parse import type 3", (t) => {
+  const parser = createParser();
+  const result = parser.parse(`
+    import { foo, bar as baz } from "module";
+  `);
+  const importResult = result.importTypeThree;
+  t.true(importResult !== undefined && importResult !== null);
+  t.true(importResult.type === "import");
+  t.true(importResult.name === "importTypeThree");
+  t.true(Array.isArray(importResult.exportedImports));
+  t.true(importResult.exportedImports.length === 2);
+  t.true(importResult.exportedImports[0].name === "foo");
+  t.true(importResult.exportedImports[0].alias === null);
+  t.true(importResult.exportedImports[1].name === "bar");
+  t.true(importResult.exportedImports[1].alias === "baz");
+  t.true(importResult.defaultImport === null);
+  t.true(importResult.alias === null);
+  t.true(importResult.from === "module");
+});
+
+test("should parse import type 4", (t) => {
+  const parser = createParser();
+  const result = parser.parse(`
+    import * as module from "module";
+  `);
+  const importResult = result.importTypeFour;
+  t.true(importResult !== undefined && importResult !== null);
+  t.true(importResult.type === "import");
+  t.true(importResult.name === "importTypeFour");
+  t.true(importResult.defaultImport === null);
+  t.true(importResult.exportedImports === null);
+  t.true(importResult.alias === "module");
+  t.true(importResult.from === "module");
+});
+
+test("should parse import type 5", (t) => {
+  const parser = createParser();
+  const result = parser.parse(`
+    import defaultExport, * as module from "module";
+  `);
+  const importResult = result.importTypeFive;
+  t.true(importResult !== undefined && importResult !== null);
+  t.true(importResult.type === "import");
+  t.true(importResult.name === "importTypeFive");
+  t.true(importResult.defaultImport === "defaultExport");
+  t.true(importResult.exportedImports === null);
+  t.true(importResult.alias === "module");
+  t.true(importResult.from === "module");
+});
+
+test("should parse import type 6", (t) => {
+  const parser = createParser();
+  const result = parser.parse(`
+    import { foo as foo2, bar as baz2 } from "module1";
+  `);
+  const importResult = result.importTypeSix;
+  t.true(importResult !== undefined && importResult !== null);
+  t.true(importResult.type === "import");
+  t.true(importResult.name === "importTypeSix");
+  t.true(Array.isArray(importResult.exportedImports));
+  t.true(importResult.defaultImport === null);
+  t.true(importResult.exportedImports.length === 2);
+  t.true(importResult.exportedImports[0].name === "foo");
+  t.true(importResult.exportedImports[0].alias === "foo2");
+  t.true(importResult.exportedImports[1].name === "bar");
+  t.true(importResult.exportedImports[1].alias === "baz2");
+  t.true(importResult.alias === null);
+  t.true(importResult.from === "module1");
+});
+
 test("should parse sample wrong refs", (t) => {
   const parser = createParser();
   t.throws(() => {


### PR DESCRIPTION
# Description

Support for import statements.
Issue: https://github.com/ckb-js/lumos/issues/643
Motivation: hyped by gems brought on the table by Lumos.
Dependencies Required: none.

Fixes # (issue)

The need for parsing import statements.
https://github.com/ckb-js/lumos/issues/643

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Testing functions are written in the file grammar.test.ts. To get started with testing, navigate to the molecule folder and run the command `npm test`

- [ ] Test A: should parse import type 1 with format `import defaultExport, { foo, bar as baz } from "module";`

- [ ] Test B: should parse import type 2 with format `import defaultExport from "module";`

- [ ] Test C: should parse import type 3 with format `import { foo, bar as baz } from "module";`

- [ ] Test D: should parse import type 4 with format `import * as module from "module";`

- [ ] Test E: should parse import type 5 with format `import defaultExport, * as module from "module";`

- [ ] Test F: should parse import type 6 with format `import { foo as foo2, bar as baz2 } from "module1";`

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules -->