### PR TITLE
fix(ckb-indexer)!: wait for the next n blocks

### DIFF
--- a/.changeset/eight-pots-invent.md
+++ b/.changeset/eight-pots-invent.md
@@ -2,4 +2,4 @@
 "@ckb-lumos/lumos": minor
 ---
 
-BREAKING CHANGE: refine the export structure
+**BREAKING CHANGE**: refine the export structure

--- a/.changeset/purple-countries-fetch.md
+++ b/.changeset/purple-countries-fetch.md
@@ -1,0 +1,5 @@
+---
+"@ckb-lumos/ckb-indexer": minor
+---
+
+**BREAKING CHANGE**: correct the semantic of the `waitForSync`

--- a/packages/ckb-indexer/src/indexer.ts
+++ b/packages/ckb-indexer/src/indexer.ts
@@ -84,14 +84,14 @@ export class CkbIndexer implements CellProvider, TerminableCellFetcher {
     return new Promise((resolve) => setTimeout(resolve, timeout));
   }
 
-  async waitForSync(blockDifference = 0): Promise<void> {
+  async waitForSync(nextNBlocks = 0): Promise<void> {
     const rpcTipNumber = parseInt(
       (await this.getCkbRpc().getTipHeader()).number,
       16
     );
     while (true) {
       const indexerTipNumber = parseInt((await this.tip()).blockNumber, 16);
-      if (indexerTipNumber + blockDifference >= rpcTipNumber) {
+      if (indexerTipNumber - nextNBlocks >= rpcTipNumber) {
         return;
       }
       await this.asyncSleep(1000);


### PR DESCRIPTION
# Description

The implementation of `waitForSync` is incorrect, although it should semantically wait for the next N blocks

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)